### PR TITLE
ci: sync README to Docker Hub overview on deploy

### DIFF
--- a/.github/workflows/deploy_docker.yml
+++ b/.github/workflows/deploy_docker.yml
@@ -58,3 +58,25 @@ jobs:
           platforms: linux/amd64,linux/arm64
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+  # Syncs README.md to the Docker Hub repository "Overview" (and short
+  # description). Runs independently of the image build so a description-sync
+  # hiccup never fails the image release, and vice versa.
+  # NOTE: peter-evans/dockerhub-description updates the description via the
+  # Docker Hub REST API. DOCKERHUB_TOKEN must be a PAT with write scope (or the
+  # account password); a read-only token will 401 here.
+  update-dockerhub-description:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Sync README to Docker Hub overview
+        uses: peter-evans/dockerhub-description@v4
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          repository: aigamedeveloper/mcp-server
+          short-description: "Engine-agnostic MCP server for the Unity, Godot & Unreal MCP plugins (Model Context Protocol)"
+          readme-filepath: ./README.md
+          enable-url-completion: true


### PR DESCRIPTION
## Why

[`aigamedeveloper/mcp-server`](https://hub.docker.com/r/aigamedeveloper/mcp-server) has a **blank Overview** on Docker Hub, unlike [`ivanmurzakdev/unity-mcp-server`](https://hub.docker.com/r/ivanmurzakdev/unity-mcp-server).

Investigation: the Unity image's Overview was sourced from the README in its docker build context (`Unity-MCP-Server/README.md`) but was **pasted into Docker Hub by hand** — there was never a CI step syncing it (confirmed across current + historical workflows). When the server moved to this repo, nothing populated the new image's page.

## What

Add an independent `update-dockerhub-description` job to `deploy_docker.yml` that uses [`peter-evans/dockerhub-description@v4`](https://github.com/peter-evans/dockerhub-description) to publish [`README.md`](README.md) (already in the build context) to the Docker Hub **Overview** + a short description — on the same triggers as the image build (release `published` + `workflow_dispatch`).

- Separate job → a description-sync failure can't fail the image release, and vice versa.
- `enable-url-completion: true` so the README's relative links resolve on Docker Hub.

## Caveat / verification

`peter-evans/dockerhub-description` updates the description via the Docker Hub REST API, which needs the `DOCKERHUB_TOKEN` secret to be a **PAT with description-write scope** (or the account password). A read-only token will `401`. If that happens, regenerate the token with write scope — no workflow change needed.

To populate the page without waiting for the next release, run the workflow manually (`workflow_dispatch`) once merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)