### PR TITLE
fix(docker): chiseled base to drop OS-package CVEs (release 8.0.1)

### DIFF
--- a/.github/workflows/deploy_docker.yml
+++ b/.github/workflows/deploy_docker.yml
@@ -34,9 +34,11 @@ jobs:
       - name: Extract version from input or release tag
         id: version
         run: |
-          version=${{ inputs.version || github.event.release.tag_name }}
+          raw="${{ inputs.version || github.event.release.tag_name }}"
+          # Release tags are v-prefixed (v8.0.1) but the image tag is not (8.0.1).
+          version="${raw#v}"
           echo "version=$version" >> $GITHUB_OUTPUT
-          echo "Extracted version: $version"
+          echo "Extracted version: $version (from $raw)"
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,10 +17,19 @@ COPY . .
 # Publish
 RUN dotnet publish "com.IvanMurzak.GameDev.MCP.Server.csproj" -c Release -o /app/publish /p:UseAppHost=false
 
-# Runtime stage
-FROM mcr.microsoft.com/dotnet/aspnet:9.0 AS final
+# Pre-create the writable logs dir so the non-root runtime user can write NLog
+# output — the chiseled rootfs has no shell to mkdir at runtime.
+RUN mkdir -p /app/publish/logs
+
+# Runtime stage — chiseled (distroless) base: no shell, no apt, no perl/pam/tar,
+# runs as a non-root user. This drops the debian-bookworm OS-package CVEs that the
+# full aspnet:9.0 base carried. The *-extra variant still ships ICU + tzdata, so
+# globalization keeps working with no application change.
+FROM mcr.microsoft.com/dotnet/aspnet:9.0-noble-chiseled-extra AS final
 WORKDIR /app
-COPY --from=build /app/publish .
+# The app user in the chiseled images is UID/GID 1654 (APP_UID). Own the app tree
+# (including logs/) so the non-root process can write NLog files.
+COPY --from=build --chown=1654:1654 /app/publish .
 
 # MCP server metadata
 LABEL io.modelcontextprotocol.server.name="io.github.IvanMurzak/GameDev-MCP-Server"

--- a/README.md
+++ b/README.md
@@ -114,9 +114,9 @@ Logs are written to `logs/server-log.txt` (and `logs/server-log-error.txt`); in 
 
 | GameDev-MCP-Server | McpPlugin.Server | ReflectorNet | Unity-MCP plugin | Godot-MCP addon | Unreal-MCP plugin |
 | --- | --- | --- | --- | --- | --- |
-| 8.0.0 | 6.7.1 | 5.3.1 | ≥ 0.80.x | ≥ 0.3.x | ≥ 0.1.x |
+| 8.0.1 | 6.7.1 | 5.3.1 | ≥ 0.80.x | ≥ 0.3.x | ≥ 0.1.x |
 
-The engine plugin versions listed are the ones pinning McpPlugin 6.7.x — any plugin built against McpPlugin 6.7.x talks to this server. The server version (8.0.0) is deliberately above every per-engine server artifact it replaces so auto-updaters treat it as newer.
+The engine plugin versions listed are the ones pinning McpPlugin 6.7.x — any plugin built against McpPlugin 6.7.x talks to this server. The server version (8.0.1) is deliberately above every per-engine server artifact it replaces so auto-updaters treat it as newer.
 
 ## License
 

--- a/com.IvanMurzak.GameDev.MCP.Server.csproj
+++ b/com.IvanMurzak.GameDev.MCP.Server.csproj
@@ -13,7 +13,7 @@
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>gamedev-mcp-server</ToolCommandName>
     <PackageId>com.IvanMurzak.GameDev.MCP.Server</PackageId>
-    <Version>8.0.0</Version>
+    <Version>8.0.1</Version>
     <Authors>Ivan Murzak</Authors>
     <Company>Ivan Murzak</Company>
     <Copyright>Copyright © 2026 Ivan Murzak</Copyright>

--- a/server.json
+++ b/server.json
@@ -7,13 +7,13 @@
     "url": "https://github.com/IvanMurzak/GameDev-MCP-Server",
     "source": "github"
   },
-  "version": "8.0.0",
+  "version": "8.0.1",
   "packages": [
     {
       "registry_type": "oci",
       "registry_base_url": "https://docker.io",
       "identifier": "aigamedeveloper/mcp-server",
-      "version": "8.0.0",
+      "version": "8.0.1",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
## Why

Docker Scout flagged multiple CVEs on [`aigamedeveloper/mcp-server`](https://hub.docker.com/r/aigamedeveloper/mcp-server), including a **9.1 critical** (`CVE-2026-12087`, perl) plus highs/mediums in `perl`, `pam`, and `tar`. All of them come from the **debian bookworm-slim** packages in the `mcr.microsoft.com/dotnet/aspnet:9.0` base image — the Dockerfile itself installs nothing.

## What

- **Runtime base → chiseled (distroless):** `aspnet:9.0-noble-chiseled-extra`. No `perl`, `pam`, `tar`, `apt`, or shell; runs as non-root (UID 1654). The `-extra` variant keeps **ICU + tzdata**, so globalization is unchanged (no `InvariantGlobalization` needed).
- **Non-root logging:** pre-create `/app/logs` in the build stage and `--chown=1654:1654` the app tree, so NLog can write (chiseled has no shell to `mkdir` at runtime).
- **Release 8.0.1:** version bumped in csproj, `server.json` (server + OCI package), and the README compatibility table.
- **Image tag fix:** `deploy_docker.yml` strips a leading `v` from the release tag, so the `v8.0.1` release publishes the image as `8.0.1` (+ `latest`) — consistent with the existing `8.0.0` tag. Git tags stay `v`-prefixed for the engine CLIs that fetch `v<version>` releases.

## Verification (local, linux/amd64)

- ✅ Image builds on chiseled-extra; boots and serves HTTP on 8080 (`GET /` → 400 is the correct MCP response, request processed, no crash).
- ✅ Non-root user (UID 1654) wrote `logs/server-log.txt` — the log-dir fix works.
- ✅ Rootfs scan: `perl`, `pam`, `tar`, and `sh/bash` **absent**; `libicu` **present**. 1790 files total (down from the full debian base).

Merging this, then publishing release **v8.0.1**, rebuilds and pushes the hardened multi-arch image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)