### PR TITLE
chore(deps): bump McpPlugin.Server to 6.10.0 (latest)

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,9 +114,9 @@ Logs are written to `logs/server-log.txt` (and `logs/server-log-error.txt`); in 
 
 | GameDev-MCP-Server | McpPlugin.Server | ReflectorNet | Unity-MCP plugin | Godot-MCP addon | Unreal-MCP plugin |
 | --- | --- | --- | --- | --- | --- |
-| 8.0.1 | 6.7.1 | 5.3.1 | ≥ 0.80.x | ≥ 0.3.x | ≥ 0.1.x |
+| 8.0.1 | 6.10.0 | 5.3.1 | ≥ 0.80.x | ≥ 0.3.x | ≥ 0.1.x |
 
-The engine plugin versions listed are the ones pinning McpPlugin 6.7.x — any plugin built against McpPlugin 6.7.x talks to this server. The server version (8.0.1) is deliberately above every per-engine server artifact it replaces so auto-updaters treat it as newer.
+The engine plugin versions listed pin McpPlugin 6.7.x; any plugin built against McpPlugin 6.x talks to this server. The server version (8.0.1) is deliberately above every per-engine server artifact it replaces so auto-updaters treat it as newer.
 
 ## License
 

--- a/com.IvanMurzak.GameDev.MCP.Server.csproj
+++ b/com.IvanMurzak.GameDev.MCP.Server.csproj
@@ -52,7 +52,7 @@
   -->
   <ItemGroup Condition="'$(UseLocalMcpPlugin)' != 'true'">
     <PackageReference Include="com.IvanMurzak.ReflectorNet" Version="5.3.1" />
-    <PackageReference Include="com.IvanMurzak.McpPlugin.Server" Version="6.7.1" />
+    <PackageReference Include="com.IvanMurzak.McpPlugin.Server" Version="6.10.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(UseLocalMcpPlugin)' == 'true'">


### PR DESCRIPTION
## What

Update the MCP server to consume the **latest** [`com.IvanMurzak.McpPlugin.Server`](https://github.com/IvanMurzak/MCP-Plugin-dotnet) from MCP-Plugin-dotnet: **6.7.1 → 6.10.0** (MCP-Plugin-dotnet HEAD is `6.10.0`).

- `ReflectorNet` stays **5.3.1** — that's what 6.10.0 depends on, and it's already the latest published.
- 6.10.0's other deps (R3 1.3.0, SignalR.Client 10.0.3, NLog.Web.AspNetCore 6.1.2) already match our direct references — so this is a single pin bump.
- No app version change: folds into the unreleased 8.0.1 on `main`. README compatibility table updated (McpPlugin.Server column 6.7.1 → 6.10.0; compat note generalized to "McpPlugin 6.x").

## Verification

- ✅ `dotnet build -c Release` against the **published** 6.10.0 package: **0 warnings / 0 errors** — no API drift in the host code.
- ✅ Server boots and listens (streamableHttp) with no errors/exceptions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)