### PR TITLE
ci: publish the global dotnet tool to NuGet on release

### DIFF
--- a/.github/workflows/deploy_nuget.yml
+++ b/.github/workflows/deploy_nuget.yml
@@ -1,0 +1,77 @@
+# ┌───────────────────────────────────────────────────────────────────────────┐
+# │  Author: Ivan Murzak (https://github.com/IvanMurzak)                      │
+# │  Repository: GitHub (https://github.com/IvanMurzak/GameDev-MCP-Server)    │
+# │  Copyright (c) 2026 Ivan Murzak                                           │
+# │  Licensed under the Apache License, Version 2.0.                          │
+# │  See the LICENSE file in the project root for more information.           │
+# └───────────────────────────────────────────────────────────────────────────┘
+
+# Packs and pushes the server as a global dotnet tool to NuGet
+# (com.IvanMurzak.GameDev.MCP.Server, command `gamedev-mcp-server`). Mirrors the
+# engine/library repos' deploy.yml NuGet job (Trusted Publishing, no stored API
+# key). Triggered by a published release (version taken from the release tag) or
+# manually via workflow_dispatch — same trigger as deploy_docker.yml /
+# deploy_server_executables.yml, so all three release channels ship together.
+
+name: deploy-nuget
+
+on:
+  release:
+    types: [published]
+
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Deploy to NuGet version (e.g., 8.0.1)."
+        required: true
+        type: string
+
+jobs:
+  deploy-to-nuget:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write   # required for NuGet Trusted Publishing (OIDC)
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Extract version from input or release tag
+        id: version
+        run: |
+          raw="${{ inputs.version || github.event.release.tag_name }}"
+          # Release tags are v-prefixed (v8.0.1) but the package version is not (8.0.1).
+          version="${raw#v}"
+          echo "version=$version" >> $GITHUB_OUTPUT
+          echo "Extracted version: $version (from $raw)"
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: "9.0.x"
+
+      - name: Restore
+        run: dotnet restore com.IvanMurzak.GameDev.MCP.Server.csproj
+
+      - name: Build (Release)
+        run: dotnet build com.IvanMurzak.GameDev.MCP.Server.csproj -c Release --no-restore
+
+      - name: Pack (global dotnet tool)
+        run: dotnet pack com.IvanMurzak.GameDev.MCP.Server.csproj --no-build --configuration Release --output ./packages
+
+      - name: Login to NuGet with Trusted Publishing
+        id: nuget_login
+        uses: NuGet/login@v1
+        with:
+          user: IvanMurzak
+
+      - name: Publish to NuGet
+        run: |
+          nupkg_file="./packages/com.IvanMurzak.GameDev.MCP.Server.${{ steps.version.outputs.version }}.nupkg"
+          if [ ! -f "$nupkg_file" ]; then
+            echo "Error: expected .nupkg not found: $nupkg_file"
+            echo "The csproj <Version> must match the release tag (minus the 'v' prefix)."
+            ls -la ./packages || true
+            exit 1
+          fi
+          echo "Deploying NuGet package: $nupkg_file (version: ${{ steps.version.outputs.version }})"
+          dotnet nuget push "$nupkg_file" --api-key ${{ steps.nuget_login.outputs.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 ## What this is
 
-Engine-agnostic C# ASP.NET Core MCP server shared by the Unity-MCP, Godot-MCP and Unreal-MCP engine plugins. Thin host (`src/Program.cs`) over the NuGet packages `com.IvanMurzak.McpPlugin.Server` + `com.IvanMurzak.ReflectorNet` — ALL real server logic lives in those packages; this repo contains no engine-specific code. Distributed as standalone executables (`gamedev-mcp-server-<rid>.zip`) and a Docker image (`aigamedeveloper/mcp-server`). (A dotnet global tool channel is deliberately NOT published yet — deferred until an engine integration needs it.)
+Engine-agnostic C# ASP.NET Core MCP server shared by the Unity-MCP, Godot-MCP and Unreal-MCP engine plugins. Thin host (`src/Program.cs`) over the NuGet packages `com.IvanMurzak.McpPlugin.Server` + `com.IvanMurzak.ReflectorNet` — ALL real server logic lives in those packages; this repo contains no engine-specific code. Distributed as standalone executables (`gamedev-mcp-server-<rid>.zip`), a Docker image (`aigamedeveloper/mcp-server`), and a global dotnet tool on NuGet (`com.IvanMurzak.GameDev.MCP.Server`, command `gamedev-mcp-server`).
 
 **NOT AI-Game-Dev-Server (the ai-game.dev cloud LLM/billing proxy) — this is the local MCP stdio/http proxy host shared by the engine plugins.**
 
@@ -21,3 +21,4 @@ dotnet run --project com.IvanMurzak.GameDev.MCP.Server.csproj -- --client-transp
 - `<Version>` in the csproj + `server.json` move together. Keep the McpPlugin.Server / ReflectorNet pins in lockstep with the engine plugins (see the Compatibility table in README.md).
 - `.github/workflows/deploy_server_executables.yml` (release-published trigger) builds, code-signs (Azure Trusted Signing on Windows, codesign+notarytool on macOS — gracefully degrading when secrets are absent) and uploads the 7 zips.
 - `.github/workflows/deploy_docker.yml` pushes `aigamedeveloper/mcp-server:<version>` + `:latest` (secrets `DOCKERHUB_USERNAME` / `DOCKERHUB_TOKEN`).
+- `.github/workflows/deploy_nuget.yml` (release-published trigger) packs the global dotnet tool and pushes `com.IvanMurzak.GameDev.MCP.Server` to NuGet via Trusted Publishing (OIDC, `NuGet/login@v1` as `IvanMurzak` — no stored API key). All three deploy workflows fire on the same published release, so the NuGet tool, Docker image, and zips ship together. **One-time setup**: the package id (or its `com.IvanMurzak.*` reserved prefix) needs a NuGet.org Trusted Publishing policy bound to `IvanMurzak/GameDev-MCP-Server` before the first release, exactly as the sibling library repos have.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
   <h1>✨ AI Game Developer — <i>GameDev MCP Server</i></h1>
 
+[![NuGet](https://img.shields.io/nuget/v/com.IvanMurzak.GameDev.MCP.Server?label=NuGet&labelColor=333A41)](https://www.nuget.org/packages/com.IvanMurzak.GameDev.MCP.Server/)
 [![MCP](https://badge.mcpx.dev 'MCP Server')](https://modelcontextprotocol.io/introduction)
 [![Unreal](https://img.shields.io/badge/Unreal-Engine-0E1128?style=flat&logo=unrealengine&logoColor=white&labelColor=333A41 'Unreal-MCP plugin')](https://github.com/IvanMurzak/Unreal-MCP)
 [![Unity](https://img.shields.io/badge/Unity-Engine-000000?style=flat&logo=unity&logoColor=white&labelColor=333A41 'Unity-MCP plugin')](https://github.com/IvanMurzak/Unity-MCP)


### PR DESCRIPTION
## What

Adds `.github/workflows/deploy_nuget.yml` — packs the server as a global dotnet tool and pushes `com.IvanMurzak.GameDev.MCP.Server` (command `gamedev-mcp-server`) to NuGet, triggered on a published GitHub release.

## Why

The csproj is **already** fully configured to pack as a tool (`PackAsTool`, `ToolCommandName`, `PackageId`, full metadata, release notes), but no workflow published it — closing the de-triplication gap: the per-engine `Unity-MCP-Server` used to publish a dotnet-tool NuGet (`unity-mcp-server`); that job was removed from Unity-MCP when the server moved here, and the shared server never picked the channel up. The `CLAUDE.md` note "dotnet global tool deliberately NOT published yet" is now stale.

## How (mirrors the engine/library repos' `deploy.yml`)

- Trigger `release: [published]` (+ `workflow_dispatch`) — the **same** trigger as `deploy_docker.yml` / `deploy_server_executables.yml`, so the NuGet tool, Docker image, and zips all ship on one release.
- restore → build (Release) → `pack --no-build` the global tool.
- Publish via **NuGet Trusted Publishing** (`NuGet/login@v1` as `IvanMurzak`, OIDC, `id-token: write`) — no stored API key, identical to the sibling repos.
- Version from the release tag (`v`-prefix stripped); the push fails loudly if the csproj `<Version>` and the tag disagree.

## Validated locally

`dotnet pack` (both `pack` and the workflow's `build` → `pack --no-build` sequence) produces `com.IvanMurzak.GameDev.MCP.Server.8.0.1.nupkg` containing `tools/net9.0/any/DotnetToolSettings.xml` + `gamedev-mcp-server.dll` + deps — a valid global tool.

## ⚠️ One-time setup before the first release

The package id `com.IvanMurzak.GameDev.MCP.Server` (or its `com.IvanMurzak.*` reserved prefix) needs a **NuGet.org Trusted Publishing policy** bound to `IvanMurzak/GameDev-MCP-Server`, exactly as the sibling library repos have. Without it the OIDC login step will fail on the first run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)