### PR TITLE
feat(host): gate Redis session migration on REDIS_URL

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -12,6 +12,9 @@ obj
 publish
 nupkg
 
+# test project (never shipped in the runtime image)
+tests
+
 # documentation
 *.md
 

--- a/.github/workflows/test_pull_request.yml
+++ b/.github/workflows/test_pull_request.yml
@@ -36,5 +36,8 @@ jobs:
       - name: Build (Release)
         run: dotnet build com.IvanMurzak.GameDev.MCP.Server.csproj -c Release --no-restore
 
+      - name: Test
+        run: dotnet test tests/GameDev.MCP.Server.Tests/GameDev.MCP.Server.Tests.csproj -c Release
+
       - name: Validate Dockerfile (build image, no push)
         run: docker build -t gamedev-mcp-server:ci .

--- a/com.IvanMurzak.GameDev.MCP.Server.csproj
+++ b/com.IvanMurzak.GameDev.MCP.Server.csproj
@@ -62,6 +62,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="9.0.15" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.3" />
     <PackageReference Include="NLog.Web.AspNetCore" Version="6.1.2" />
     <PackageReference Include="R3" Version="1.3.0" />
@@ -84,6 +85,19 @@
     <None Remove="publish/**" />
     <Content Remove="publish/**" />
     <EmbeddedResource Remove="publish/**" />
+  </ItemGroup>
+
+  <!--
+    This root Microsoft.NET.Sdk.Web project globs **/*.cs from the repo root, so it
+    would otherwise try to compile the xUnit test sources under tests/ (breaking both
+    `dotnet build` and the Dockerfile's `dotnet publish`). The test project builds on
+    its own via `dotnet test tests/.../*.csproj`. Exclude tests/ from the host project.
+  -->
+  <ItemGroup>
+    <Compile Remove="tests/**/*.cs" />
+    <Content Remove="tests/**/*" />
+    <EmbeddedResource Remove="tests/**/*" />
+    <None Remove="tests/**/*" />
   </ItemGroup>
 
 </Project>

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -17,10 +17,13 @@ using com.IvanMurzak.McpPlugin.Server;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Caching.Distributed;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using ModelContextProtocol.AspNetCore;
 using NLog;
 using NLog.Extensions.Logging;
+using StackExchange.Redis;
 
 namespace com.IvanMurzak.GameDev.MCP.Server
 {
@@ -75,9 +78,61 @@ namespace com.IvanMurzak.GameDev.MCP.Server
 
                 // Setup MCP Plugin ---------------------------------------------------------------
 
-                builder.Services
+                var mcpServerBuilder = builder.Services
                     .WithMcpServer(dataArguments, logger)
                     .WithMcpPluginServer(dataArguments);
+
+                // Issue #70 — Option B: when REDIS_URL is set, plug Redis into the SDK's
+                // session-migration + SSE event-store hooks so sessions survive a restart.
+                // When unset, the server skips the registrations and behaves as before
+                // (sessions are lost on restart) — a startup warning is logged below.
+                var redisUrl = builder.Configuration["REDIS_URL"];
+                var streamableHttp = dataArguments.ClientTransport == Consts.MCP.Server.TransportMethod.streamableHttp;
+                var sessionPersistenceEnabled = streamableHttp && !string.IsNullOrWhiteSpace(redisUrl);
+
+                if (sessionPersistenceEnabled)
+                {
+                    // StackExchange.Redis's ConfigurationOptions.Parse expects "host:port[,opt=val,...]"
+                    // form, NOT a URI like "redis://host:port/db". The rest of the stack uses the URI
+                    // form (.env.example, docker-compose, the Python backend's redis-py), so normalize
+                    // here before parsing — otherwise Parse keeps "redis://host" as the host name and
+                    // the connection target becomes "redis://host:port/db:6379", which never resolves.
+                    var redisConfigString = NormalizeRedisUrlForStackExchange(redisUrl!);
+
+                    builder.Services.AddStackExchangeRedisCache(options =>
+                    {
+                        var redisConfig = ConfigurationOptions.Parse(redisConfigString);
+                        redisConfig.AbortOnConnectFail = false;
+                        redisConfig.ConnectRetry = 3;
+                        redisConfig.ConnectTimeout = 2000;
+                        redisConfig.SyncTimeout = 2000;
+                        options.ConfigurationOptions = redisConfig;
+                        // MCP_REDIS_KEY_PREFIX namespaces this server's cache entries in Redis so
+                        // multiple stacks (parallel worktrees, blue/green deployments, multi-tenant
+                        // shared-Redis hosts) can share one Redis instance without colliding on keys.
+                        // Defaults to "mcp-server:" to preserve historical behaviour.
+                        options.InstanceName = builder.Configuration["MCP_REDIS_KEY_PREFIX"] ?? "mcp-server:";
+                    });
+
+                    // Resolve the migration-record TTL from config (issue #209). The previous
+                    // hardcoded 2h sliding window expired recovery records long before the
+                    // in-memory idle window (up to 10h in prod) released the session, so any
+                    // session older than 2h was lost on restart. ResolveTtl sources an explicit
+                    // MCP_SESSION_MIGRATION_TTL_SECONDS override, else falls back to the in-memory
+                    // idle window (MCP_PLUGIN_IDLE_TIMEOUT_SECONDS), else a 10h default — always
+                    // floored at the idle timeout so the recovery window can never be shorter than
+                    // the in-memory session lifetime.
+                    var sessionMigrationTtl = SessionMigrationHandler.ResolveTtl(
+                        builder.Configuration[SessionMigrationHandler.MigrationTtlEnvVar],
+                        builder.Configuration[SessionMigrationHandler.IdleTimeoutEnvVar]);
+
+                    builder.Services.AddSingleton<ISessionMigrationHandler>(sp =>
+                        new SessionMigrationHandler(
+                            sp.GetRequiredService<IDistributedCache>(),
+                            sp.GetRequiredService<ILogger<SessionMigrationHandler>>(),
+                            sessionMigrationTtl));
+                    mcpServerBuilder.WithDistributedCacheEventStreamStore();
+                }
 
                 // builder.WebHost.UseUrls(Consts.Hub.DefaultEndpoint);
 
@@ -87,6 +142,13 @@ namespace com.IvanMurzak.GameDev.MCP.Server
                 builder.WebHost.UseKestrelForMcpPlugin(dataArguments.Port);
 
                 var app = builder.Build();
+
+                if (streamableHttp && !sessionPersistenceEnabled)
+                {
+                    app.Logger.LogWarning(
+                        "REDIS_URL is not set — MCP sessions will NOT survive a server restart. "
+                        + "Configure Redis to enable Option B (issue #70).");
+                }
 
                 // Middleware ----------------------------------------------------------------
                 // ---------------------------------------------------------------------------
@@ -151,6 +213,59 @@ namespace com.IvanMurzak.GameDev.MCP.Server
             {
                 LogManager.Shutdown();
             }
+        }
+
+        /// <summary>
+        /// Convert a redis-URI-style connection string (redis://[user:pass@]host:port[/db])
+        /// into the host:port[,password=...,defaultDatabase=N,ssl=True] form that
+        /// StackExchange.Redis's ConfigurationOptions.Parse understands. Strings that
+        /// already use the host:port form are returned unchanged.
+        /// </summary>
+        internal static string NormalizeRedisUrlForStackExchange(string redisUrl)
+        {
+            if (string.IsNullOrWhiteSpace(redisUrl))
+                return redisUrl;
+
+            var trimmed = redisUrl.Trim();
+            var lower = trimmed.ToLowerInvariant();
+            if (!lower.StartsWith("redis://") && !lower.StartsWith("rediss://"))
+                return trimmed; // already in StackExchange.Redis form (host:port,...)
+
+            if (!Uri.TryCreate(trimmed, UriKind.Absolute, out var uri))
+                return trimmed; // fall through; let Parse surface the error
+
+            var host = string.IsNullOrEmpty(uri.Host) ? "localhost" : uri.Host;
+            var port = uri.Port > 0 ? uri.Port : 6379;
+            var sb = new System.Text.StringBuilder();
+            sb.Append(host).Append(':').Append(port);
+
+            // userinfo -> password=...,user=...
+            if (!string.IsNullOrEmpty(uri.UserInfo))
+            {
+                var userInfo = uri.UserInfo;
+                var colonIdx = userInfo.IndexOf(':');
+                string user = colonIdx >= 0 ? userInfo.Substring(0, colonIdx) : string.Empty;
+                string password = colonIdx >= 0 ? userInfo.Substring(colonIdx + 1) : userInfo;
+                if (!string.IsNullOrEmpty(password))
+                    sb.Append(",password=").Append(Uri.UnescapeDataString(password));
+                if (!string.IsNullOrEmpty(user))
+                    sb.Append(",user=").Append(Uri.UnescapeDataString(user));
+            }
+
+            // path -> /<db>
+            var path = uri.AbsolutePath;
+            if (!string.IsNullOrEmpty(path) && path.Length > 1)
+            {
+                var dbStr = path.TrimStart('/');
+                if (int.TryParse(dbStr, out var db) && db >= 0)
+                    sb.Append(",defaultDatabase=").Append(db);
+            }
+
+            // rediss:// -> ssl=True
+            if (lower.StartsWith("rediss://"))
+                sb.Append(",ssl=True");
+
+            return sb.ToString();
         }
     }
 }

--- a/src/SessionMigrationHandler.cs
+++ b/src/SessionMigrationHandler.cs
@@ -1,0 +1,302 @@
+/*
+┌───────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                      │
+│  Repository: GitHub (https://github.com/IvanMurzak/GameDev-MCP-Server)    │
+│  Copyright (c) 2026 Ivan Murzak                                           │
+│  Licensed under the Apache License, Version 2.0.                          │
+│  See the LICENSE file in the project root for more information.           │
+└───────────────────────────────────────────────────────────────────────────┘
+*/
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Caching.Distributed;
+using Microsoft.Extensions.Logging;
+using ModelContextProtocol;
+using ModelContextProtocol.AspNetCore;
+using ModelContextProtocol.Protocol;
+
+namespace com.IvanMurzak.GameDev.MCP.Server
+{
+    /// <summary>
+    /// Persists MCP session <see cref="InitializeRequestParams"/> to a shared
+    /// <see cref="IDistributedCache"/> so a fresh server process can rehydrate a session
+    /// whose ID it has never seen in memory. Closes the "lose session on restart" gap.
+    /// See https://github.com/IvanMurzak/AI-Game-Dev-Server/issues/70 (Option B).
+    /// Final Redis key is <c>{InstanceName}{KeyPrefix}{sessionId}</c>, e.g.
+    /// <c>mcp-server:mcp:session:&lt;sessionId&gt;</c>.
+    /// </summary>
+    public sealed class SessionMigrationHandler : ISessionMigrationHandler
+    {
+        // Floor for the migration-record TTL when neither env var is set. Chosen to be >=
+        // the in-memory idle window deployed in prod (MCP_PLUGIN_IDLE_TIMEOUT_SECONDS=36000
+        // = 10h on the VPS). A recovery record that outlives the in-memory session by a
+        // comfortable margin guarantees a restart can always rehydrate any session the
+        // in-memory layer still considers live. See issue #209.
+        public static readonly TimeSpan DefaultSessionTtl = TimeSpan.FromHours(10);
+
+        // Sane ceiling for a configured TTL. A pathological value (e.g. 1e15 seconds)
+        // would overflow TimeSpan.FromSeconds and throw OverflowException, which is NOT
+        // caught here and would crash startup — violating the fail-open contract. Any
+        // value above this cap is clamped down to it instead of throwing. 30 days is far
+        // longer than any plausible continuous session yet well inside TimeSpan's range.
+        public static readonly TimeSpan MaxSessionTtl = TimeSpan.FromDays(30);
+
+        // Env var names this handler resolves its TTL from. Kept here (rather than only in
+        // Program.cs) so the resolution helper and its tests share one source of truth.
+        public const string MigrationTtlEnvVar = "MCP_SESSION_MIGRATION_TTL_SECONDS";
+        public const string IdleTimeoutEnvVar = "MCP_PLUGIN_IDLE_TIMEOUT_SECONDS";
+
+        private const string KeyPrefix = "mcp:session:";
+
+        // Defence-in-depth: validate Mcp-Session-Id format ourselves before using it as
+        // a Redis key suffix, instead of trusting the upstream MCP SDK alone (issue #72).
+        // Pattern intentionally narrower than the SDK accepts — covers Guid.NewGuid()
+        // ("N" = 32 hex chars; "D" = 36 with hyphens) and base64url-style IDs, blocks
+        // separators, control chars, and oversized payloads that could bloat Redis or
+        // confuse namespace-scanning tooling (KEYS / SCAN / dashboards).
+        [StringSyntax(StringSyntaxAttribute.Regex)]
+        private const string SessionIdPatternText = @"^[A-Za-z0-9_\-]{1,128}$";
+
+        // Explicit ReDoS belt: the current charset class is linear, but a small timeout
+        // keeps the contract intact if the pattern is ever broadened.
+        private static readonly Regex SessionIdPattern = new(
+            SessionIdPatternText,
+            RegexOptions.Compiled,
+            TimeSpan.FromMilliseconds(50));
+
+        // Canonical log message for failed defensive session-ID validation. Distinguished
+        // per call site by the structured {Phase} property (Init|Migration) so a single
+        // alert/grep query covers both paths.
+        private const string SessionIdValidationFailedMessage =
+            "Rejecting MCP session: session ID failed defensive format validation. Phase={Phase}, SessionIdLength={SessionIdLength}";
+
+        private static bool IsValidSessionId(string? sessionId)
+            => !string.IsNullOrEmpty(sessionId) && SessionIdPattern.IsMatch(sessionId);
+
+        private readonly IDistributedCache _cache;
+        private readonly ILogger<SessionMigrationHandler> _logger;
+        private readonly TimeSpan _sessionTtl;
+        private readonly DistributedCacheEntryOptions _cacheEntryOptions;
+
+        public SessionMigrationHandler(
+            IDistributedCache cache,
+            ILogger<SessionMigrationHandler> logger)
+            : this(cache, logger, DefaultSessionTtl)
+        {
+        }
+
+        public SessionMigrationHandler(
+            IDistributedCache cache,
+            ILogger<SessionMigrationHandler> logger,
+            TimeSpan sessionTtl)
+        {
+            _cache = cache ?? throw new ArgumentNullException(nameof(cache));
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+            _sessionTtl = sessionTtl > TimeSpan.Zero ? sessionTtl : DefaultSessionTtl;
+            // ABSOLUTE (relative-to-now) expiration, deliberately NOT sliding. The previous
+            // implementation used SlidingExpiration on the assumption that an active client
+            // would refresh the window on every reconnect — that assumption was FALSE for this
+            // access pattern (issue #209). The hot path keeps the session in memory and never
+            // calls IDistributedCache.GetAsync for a live session, so the sliding window never
+            // rolled; it just counted down from `initialize`. A 2h sliding window therefore
+            // expired the recovery record while the in-memory session (idle window up to 10h)
+            // was still alive, so a restart 404'd every session older than 2h.
+            //
+            // The fix: a single absolute TTL sized to cover the longest expected continuous
+            // session (>= the in-memory idle window, see ResolveTtl). The record is written
+            // once at `initialize` and lives for the full window regardless of reconnect
+            // traffic — simpler and correct, because rolling the window on the hot path would
+            // require a redundant cache read we deliberately avoid.
+            _cacheEntryOptions = new DistributedCacheEntryOptions
+            {
+                AbsoluteExpirationRelativeToNow = _sessionTtl,
+            };
+        }
+
+        /// <summary>
+        /// Pure resolution of the migration-record TTL from raw env-var string values, so the
+        /// policy is unit-testable without Redis or a live <see cref="IConfiguration"/>.
+        /// Precedence:
+        /// <list type="number">
+        ///   <item><see cref="MigrationTtlEnvVar"/> (<c>MCP_SESSION_MIGRATION_TTL_SECONDS</c>), if a positive integer — it wins outright.</item>
+        ///   <item>else <see cref="IdleTimeoutEnvVar"/> (<c>MCP_PLUGIN_IDLE_TIMEOUT_SECONDS</c>), if a positive integer — the recovery window then tracks the in-memory idle window.</item>
+        ///   <item>else <see cref="DefaultSessionTtl"/> (10h).</item>
+        /// </list>
+        /// In all cases the result is floored at the resolved idle timeout (when that is a
+        /// positive integer) so the recovery window can NEVER be shorter than the in-memory
+        /// session lifetime — that shorter-window state is exactly the bug in issue #209.
+        /// Malformed / non-positive values are ignored (treated as unset) rather than throwing,
+        /// to fail open: a bad override must not crash startup. A pathologically large value is
+        /// clamped to <see cref="MaxSessionTtl"/> for the same reason (the raw conversion would
+        /// otherwise overflow <see cref="TimeSpan"/> and throw).
+        /// </summary>
+        /// <param name="migrationTtlRaw">Raw value of <c>MCP_SESSION_MIGRATION_TTL_SECONDS</c> (may be null/empty/garbage).</param>
+        /// <param name="idleTimeoutRaw">Raw value of <c>MCP_PLUGIN_IDLE_TIMEOUT_SECONDS</c> (may be null/empty/garbage).</param>
+        public static TimeSpan ResolveTtl(string? migrationTtlRaw, string? idleTimeoutRaw)
+        {
+            var explicitTtl = ParsePositiveSeconds(migrationTtlRaw);
+            var idleTimeout = ParsePositiveSeconds(idleTimeoutRaw);
+
+            // Base TTL: explicit override > idle-timeout fallback > hard default.
+            var ttl = explicitTtl ?? idleTimeout ?? DefaultSessionTtl;
+
+            // Floor at the idle timeout (when known) so the recovery window can never be
+            // shorter than the in-memory session lifetime — the issue #209 regression.
+            if (idleTimeout is { } floor && ttl < floor)
+                ttl = floor;
+
+            return ttl;
+        }
+
+        /// <summary>
+        /// Parse a string as a strictly-positive whole number of seconds into a
+        /// <see cref="TimeSpan"/>. Returns null for null/empty/non-numeric/&lt;=0 input so the
+        /// caller can treat any malformed value as "unset" and fall through to the next source.
+        /// </summary>
+        private static TimeSpan? ParsePositiveSeconds(string? raw)
+        {
+            if (string.IsNullOrWhiteSpace(raw))
+                return null;
+            if (!long.TryParse(raw.Trim(), NumberStyles.Integer, CultureInfo.InvariantCulture, out var seconds))
+                return null;
+            if (seconds <= 0)
+                return null;
+            // Clamp before converting: TimeSpan.FromSeconds overflows (and throws) for very
+            // large inputs, so cap at MaxSessionTtl to keep the parse fail-open and total.
+            if (seconds >= (long)MaxSessionTtl.TotalSeconds)
+                return MaxSessionTtl;
+            return TimeSpan.FromSeconds(seconds);
+        }
+
+        public async ValueTask OnSessionInitializedAsync(
+            HttpContext context,
+            string sessionId,
+            InitializeRequestParams initializeParams,
+            CancellationToken cancellationToken)
+        {
+            if (string.IsNullOrEmpty(sessionId))
+                return;
+
+            if (!IsValidSessionId(sessionId))
+            {
+                // Length-only log — never echo the raw ID, per issue #72 acceptance criteria.
+                _logger.LogWarning(
+                    SessionIdValidationFailedMessage,
+                    "Init",
+                    sessionId.Length);
+                return;
+            }
+
+            try
+            {
+                var payload = JsonSerializer.SerializeToUtf8Bytes(
+                    initializeParams,
+                    McpJsonUtilities.DefaultOptions);
+
+                await _cache.SetAsync(BuildKey(sessionId), payload, _cacheEntryOptions, cancellationToken)
+                    .ConfigureAwait(false);
+
+                _logger.LogDebug(
+                    "Persisted MCP session init params to distributed cache. SessionId={SessionId}, TtlSeconds={TtlSeconds}, Bytes={Bytes}",
+                    sessionId, (long)_sessionTtl.TotalSeconds, payload.Length);
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                // Persistence failure must NOT break the live session — worst case is this
+                // session can't migrate after a restart (same as before this handler existed).
+                _logger.LogWarning(ex,
+                    "Failed to persist MCP session init params for migration. SessionId={SessionId}",
+                    sessionId);
+            }
+        }
+
+        public async ValueTask<InitializeRequestParams?> AllowSessionMigrationAsync(
+            HttpContext context,
+            string sessionId,
+            CancellationToken cancellationToken)
+        {
+            if (string.IsNullOrEmpty(sessionId))
+                return null;
+
+            if (!IsValidSessionId(sessionId))
+            {
+                _logger.LogWarning(
+                    SessionIdValidationFailedMessage,
+                    "Migration",
+                    sessionId.Length);
+                return null;
+            }
+
+            byte[]? payload;
+            try
+            {
+                // Read the persisted init params. The TTL is absolute (see ctor) — this read
+                // does NOT extend it, and intentionally so: the record is sized to outlive the
+                // longest expected session, so there is no window to refresh here.
+                payload = await _cache.GetAsync(BuildKey(sessionId), cancellationToken)
+                    .ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                // Cache outage: we can't tell real from forged, so reject migration.
+                // Client gets 404 and re-initializes — same as if no handler existed.
+                _logger.LogWarning(ex,
+                    "Distributed cache lookup failed during MCP session migration; rejecting reconnect. SessionId={SessionId}",
+                    sessionId);
+                return null;
+            }
+
+            if (payload == null || payload.Length == 0)
+            {
+                _logger.LogDebug(
+                    "No persisted init params found for unrecognised MCP session ID. SessionId={SessionId}",
+                    sessionId);
+                return null;
+            }
+
+            try
+            {
+                var initializeParams = JsonSerializer.Deserialize<InitializeRequestParams>(
+                    payload,
+                    McpJsonUtilities.DefaultOptions);
+                if (initializeParams == null)
+                {
+                    _logger.LogWarning(
+                        "Deserialised init params were null; rejecting MCP session migration. SessionId={SessionId}",
+                        sessionId);
+                    return null;
+                }
+
+                _logger.LogInformation(
+                    "Rehydrated MCP session from distributed cache after process restart. SessionId={SessionId}",
+                    sessionId);
+                return initializeParams;
+            }
+            catch (JsonException ex)
+            {
+                _logger.LogWarning(ex,
+                    "Failed to deserialise persisted MCP init params; rejecting migration. SessionId={SessionId}",
+                    sessionId);
+                return null;
+            }
+        }
+
+        private static string BuildKey(string sessionId)
+            => KeyPrefix + sessionId;
+    }
+}

--- a/tests/GameDev.MCP.Server.Tests/GameDev.MCP.Server.Tests.csproj
+++ b/tests/GameDev.MCP.Server.Tests/GameDev.MCP.Server.Tests.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <!-- Matches the TFM of the host project (com.IvanMurzak.GameDev.MCP.Server.csproj). -->
+    <TargetFramework>net9.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <IsPackable>false</IsPackable>
+    <RootNamespace>com.IvanMurzak.GameDev.MCP.Server.Tests</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <!-- Reference the host project under test. ASP.NET Core (Microsoft.AspNetCore.App)
+         + the ModelContextProtocol / Microsoft.Extensions.Caching.Abstractions types the
+         tests use (DefaultHttpContext, InitializeRequestParams, IDistributedCache) flow
+         in transitively through this reference, so no explicit FrameworkReference or
+         extra package pins are needed. -->
+    <ProjectReference Include="..\..\com.IvanMurzak.GameDev.MCP.Server.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/GameDev.MCP.Server.Tests/SessionMigrationTtlTests.cs
+++ b/tests/GameDev.MCP.Server.Tests/SessionMigrationTtlTests.cs
@@ -1,0 +1,223 @@
+/*
+┌───────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                      │
+│  Repository: GitHub (https://github.com/IvanMurzak/GameDev-MCP-Server)    │
+│  Copyright (c) 2026 Ivan Murzak                                           │
+│  Licensed under the Apache License, Version 2.0.                          │
+│  See the LICENSE file in the project root for more information.           │
+└───────────────────────────────────────────────────────────────────────────┘
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using com.IvanMurzak.GameDev.MCP.Server;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Caching.Distributed;
+using Microsoft.Extensions.Logging.Abstractions;
+using ModelContextProtocol.Protocol;
+using Xunit;
+
+namespace com.IvanMurzak.GameDev.MCP.Server.Tests
+{
+    /// <summary>
+    /// Covers the issue #209 fix: the migration-record TTL is configurable, defaults to a
+    /// window >= the in-memory idle timeout, and is actually applied to the cache entry as an
+    /// absolute (not sliding) expiration.
+    /// </summary>
+    public class SessionMigrationTtlTests
+    {
+        // ── ResolveTtl: precedence + clamp/floor ────────────────────────────────────────
+
+        [Fact]
+        public void ResolveTtl_NeitherEnvSet_UsesTenHourDefault()
+        {
+            var ttl = SessionMigrationHandler.ResolveTtl(migrationTtlRaw: null, idleTimeoutRaw: null);
+            Assert.Equal(SessionMigrationHandler.DefaultSessionTtl, ttl);
+            Assert.Equal(TimeSpan.FromHours(10), ttl);
+        }
+
+        [Fact]
+        public void ResolveTtl_ExplicitOverride_Wins()
+        {
+            // Explicit override above the idle window wins outright.
+            var ttl = SessionMigrationHandler.ResolveTtl(
+                migrationTtlRaw: "50000",
+                idleTimeoutRaw: "36000");
+            Assert.Equal(TimeSpan.FromSeconds(50000), ttl);
+        }
+
+        [Fact]
+        public void ResolveTtl_NoOverride_FallsBackToIdleTimeout()
+        {
+            // No explicit override → track the in-memory idle window (10h prod value).
+            var ttl = SessionMigrationHandler.ResolveTtl(
+                migrationTtlRaw: null,
+                idleTimeoutRaw: "36000");
+            Assert.Equal(TimeSpan.FromSeconds(36000), ttl);
+        }
+
+        [Fact]
+        public void ResolveTtl_ExplicitBelowIdleTimeout_IsFlooredAtIdleTimeout()
+        {
+            // The core issue #209 guard: a too-short explicit override is raised to the idle
+            // window so the recovery record can never expire before the in-memory session.
+            var ttl = SessionMigrationHandler.ResolveTtl(
+                migrationTtlRaw: "7200",   // the old buggy 2h value
+                idleTimeoutRaw: "36000");  // 10h in-memory window
+            Assert.Equal(TimeSpan.FromSeconds(36000), ttl);
+        }
+
+        [Theory]
+        [InlineData("", "")]
+        [InlineData("   ", null)]
+        [InlineData("not-a-number", "also-bad")]
+        [InlineData("0", "0")]
+        [InlineData("-5", "-100")]
+        public void ResolveTtl_MalformedOrNonPositive_TreatedAsUnset(string? migration, string? idle)
+        {
+            // Garbage / non-positive values fail open to the hard default rather than throwing.
+            var ttl = SessionMigrationHandler.ResolveTtl(migration, idle);
+            Assert.Equal(SessionMigrationHandler.DefaultSessionTtl, ttl);
+        }
+
+        [Fact]
+        public void ResolveTtl_MalformedOverride_FallsThroughToIdleTimeout()
+        {
+            var ttl = SessionMigrationHandler.ResolveTtl(
+                migrationTtlRaw: "garbage",
+                idleTimeoutRaw: "36000");
+            Assert.Equal(TimeSpan.FromSeconds(36000), ttl);
+        }
+
+        [Fact]
+        public void ResolveTtl_OverrideAboveIdle_NotClampedDown()
+        {
+            // The floor never lowers a deliberately-larger TTL.
+            var ttl = SessionMigrationHandler.ResolveTtl(
+                migrationTtlRaw: "72000", // 20h
+                idleTimeoutRaw: "36000"); // 10h
+            Assert.Equal(TimeSpan.FromSeconds(72000), ttl);
+        }
+
+        [Fact]
+        public void ResolveTtl_ExplicitEqualsIdleExactly_StaysAtThatValue()
+        {
+            // Boundary: explicit == idle. The floor uses `<` so an exactly-equal value is not
+            // raised; it passes through unchanged (and is not double-counted by the clamp).
+            var ttl = SessionMigrationHandler.ResolveTtl(
+                migrationTtlRaw: "36000",
+                idleTimeoutRaw: "36000");
+            Assert.Equal(TimeSpan.FromSeconds(36000), ttl);
+        }
+
+        [Fact]
+        public void ResolveTtl_PathologicallyLargeOverride_FailsOpenToCeiling()
+        {
+            // A value that would overflow TimeSpan.FromSeconds must NOT throw (fail-open
+            // contract). It is clamped to MaxSessionTtl instead of crashing startup.
+            var ttl = SessionMigrationHandler.ResolveTtl(
+                migrationTtlRaw: "1000000000000000", // 1e15 s — overflows TimeSpan ticks
+                idleTimeoutRaw: "36000");
+            Assert.Equal(SessionMigrationHandler.MaxSessionTtl, ttl);
+        }
+
+        // ── Handler applies the resolved TTL to its cache entry (absolute, not sliding) ──
+
+        [Fact]
+        public async Task OnSessionInitialized_AppliesResolvedTtl_AsAbsoluteExpiration()
+        {
+            var resolved = SessionMigrationHandler.ResolveTtl(
+                migrationTtlRaw: "36000",
+                idleTimeoutRaw: "600");
+            var recordingCache = new RecordingDistributedCache();
+            var handler = new SessionMigrationHandler(
+                recordingCache,
+                NullLogger<SessionMigrationHandler>.Instance,
+                resolved);
+
+            await handler.OnSessionInitializedAsync(
+                new DefaultHttpContext(),
+                sessionId: "abc123",
+                initializeParams: NewInitializeParams(),
+                CancellationToken.None);
+
+            Assert.NotNull(recordingCache.LastOptions);
+            // Absolute relative TTL is set to exactly the resolved value …
+            Assert.Equal(resolved, recordingCache.LastOptions!.AbsoluteExpirationRelativeToNow);
+            // … and sliding expiration is NOT used (the issue #209 regression source).
+            Assert.Null(recordingCache.LastOptions.SlidingExpiration);
+        }
+
+        [Fact]
+        public async Task OnSessionInitialized_NonPositiveTtl_FallsBackToDefault()
+        {
+            // The 3-arg ctor guards against a non-positive TimeSpan by using the default.
+            var recordingCache = new RecordingDistributedCache();
+            var handler = new SessionMigrationHandler(
+                recordingCache,
+                NullLogger<SessionMigrationHandler>.Instance,
+                TimeSpan.Zero);
+
+            await handler.OnSessionInitializedAsync(
+                new DefaultHttpContext(),
+                sessionId: "abc123",
+                initializeParams: NewInitializeParams(),
+                CancellationToken.None);
+
+            Assert.NotNull(recordingCache.LastOptions);
+            Assert.Equal(
+                SessionMigrationHandler.DefaultSessionTtl,
+                recordingCache.LastOptions!.AbsoluteExpirationRelativeToNow);
+        }
+
+        private static InitializeRequestParams NewInitializeParams() => new()
+        {
+            ProtocolVersion = "2024-11-05",
+            Capabilities = new ClientCapabilities(),
+            ClientInfo = new Implementation { Name = "test-client", Version = "1.0.0" },
+        };
+
+        /// <summary>
+        /// Minimal in-memory <see cref="IDistributedCache"/> test double that records the
+        /// <see cref="DistributedCacheEntryOptions"/> passed to <c>SetAsync</c> so the test can
+        /// assert the expiration policy without a live Redis.
+        /// </summary>
+        private sealed class RecordingDistributedCache : IDistributedCache
+        {
+            private readonly Dictionary<string, byte[]> _store = new();
+
+            public DistributedCacheEntryOptions? LastOptions { get; private set; }
+
+            public byte[]? Get(string key) => _store.TryGetValue(key, out var v) ? v : null;
+
+            public Task<byte[]?> GetAsync(string key, CancellationToken token = default)
+                => Task.FromResult(Get(key));
+
+            public void Set(string key, byte[] value, DistributedCacheEntryOptions options)
+            {
+                LastOptions = options;
+                _store[key] = value;
+            }
+
+            public Task SetAsync(string key, byte[] value, DistributedCacheEntryOptions options, CancellationToken token = default)
+            {
+                Set(key, value, options);
+                return Task.CompletedTask;
+            }
+
+            public void Refresh(string key) { }
+
+            public Task RefreshAsync(string key, CancellationToken token = default) => Task.CompletedTask;
+
+            public void Remove(string key) => _store.Remove(key);
+
+            public Task RemoveAsync(string key, CancellationToken token = default)
+            {
+                _store.Remove(key);
+                return Task.CompletedTask;
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Port the Redis session-migration feature from the vendored cloud host (`AI-Game-Dev-Server/mcp-server`) into the shared `GameDev-MCP-Server`, so the published `aigamedeveloper/mcp-server` image can serve the production cloud role (MCP session continuity across restarts).
- `SessionMigrationHandler` (IDistributedCache-backed) carries the cloud host's **absolute-TTL fix** (`ResolveTtl` precedence + idle-window floor, deliberately NOT sliding — the sliding-window bug is not reintroduced).
- `Program.cs` wires the block **gated on `REDIS_URL`** after `WithMcpPluginServer(...)`: `AddStackExchangeRedisCache` (`InstanceName` from `MCP_REDIS_KEY_PREFIX`, default `mcp-server:`), TTL resolution (`MCP_SESSION_MIGRATION_TTL_SECONDS` / `MCP_PLUGIN_IDLE_TIMEOUT_SECONDS`), `AddSingleton<ISessionMigrationHandler>`, `WithDistributedCacheEventStreamStore()`, plus the fail-open startup warning and the `NormalizeRedisUrlForStackExchange` helper.
- **Gated + fail-open**: when `REDIS_URL` is unset the server behaves exactly as today (no Redis wiring; existing "REDIS_URL is not set" warning in streamableHttp mode). Non-cloud Unity/Godot/Unreal local users are unaffected.
- Adds the new dependency `Microsoft.Extensions.Caching.StackExchangeRedis` `9.0.15` to the unconditional csproj ItemGroup. `<Version>` (8.0.1) and the `McpPlugin.Server` / `ReflectorNet` pins are unchanged.

## First test project for this repo
This introduces the repository's **first xUnit test project** (`tests/GameDev.MCP.Server.Tests`, TTL/precedence coverage) and wires a `dotnet test` step into `test_pull_request.yml` so the tests gate CI from now on. `tests/**` is excluded from the host project's compile glob and from `.dockerignore` so the `Microsoft.NET.Sdk.Web` build and the Dockerfile publish do not double-compile the test sources. The `dotnet test` step runs inside the existing `build` job (CI matcher stays single-job / `build`).

## Test plan
- [x] `dotnet restore` + `dotnet build -c Release --no-restore` — 0 warnings, 0 errors
- [x] `dotnet test tests/GameDev.MCP.Server.Tests/...` — 15/15 passed
- [x] `docker build -t gamedev-mcp-server:ci .` — image builds; publish does not choke on `tests/`

Closes #7