### PR TITLE
chore(release): 8.0.1 -> 8.0.2 (session-migration)

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,9 +116,9 @@ Logs are written to `logs/server-log.txt` (and `logs/server-log-error.txt`); in 
 
 | GameDev-MCP-Server | McpPlugin.Server | ReflectorNet | Unity-MCP plugin | Godot-MCP addon | Unreal-MCP plugin |
 | --- | --- | --- | --- | --- | --- |
-| 8.0.1 | 6.10.0 | 5.3.1 | ≥ 0.80.x | ≥ 0.3.x | ≥ 0.1.x |
+| 8.0.2 | 6.10.0 | 5.3.1 | ≥ 0.80.x | ≥ 0.3.x | ≥ 0.1.x |
 
-The engine plugin versions listed pin McpPlugin 6.7.x; any plugin built against McpPlugin 6.x talks to this server. The server version (8.0.1) is deliberately above every per-engine server artifact it replaces so auto-updaters treat it as newer.
+The engine plugin versions listed pin McpPlugin 6.7.x; any plugin built against McpPlugin 6.x talks to this server. The server version (8.0.2) is deliberately above every per-engine server artifact it replaces so auto-updaters treat it as newer.
 
 ## License
 

--- a/com.IvanMurzak.GameDev.MCP.Server.csproj
+++ b/com.IvanMurzak.GameDev.MCP.Server.csproj
@@ -13,7 +13,7 @@
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>gamedev-mcp-server</ToolCommandName>
     <PackageId>com.IvanMurzak.GameDev.MCP.Server</PackageId>
-    <Version>8.0.1</Version>
+    <Version>8.0.2</Version>
     <Authors>Ivan Murzak</Authors>
     <Company>Ivan Murzak</Company>
     <Copyright>Copyright © 2026 Ivan Murzak</Copyright>

--- a/docs/NUGET.md
+++ b/docs/NUGET.md
@@ -73,7 +73,7 @@ In stdio mode console logging is redirected to stderr so stdout stays clean for 
 
 | GameDev-MCP-Server | McpPlugin.Server | ReflectorNet | Unity-MCP plugin | Godot-MCP addon | Unreal-MCP plugin |
 | --- | --- | --- | --- | --- | --- |
-| 8.0.1 | 6.10.0 | 5.3.1 | >= 0.80.x | >= 0.3.x | >= 0.1.x |
+| 8.0.2 | 6.10.0 | 5.3.1 | >= 0.80.x | >= 0.3.x | >= 0.1.x |
 
 Any engine plugin built against McpPlugin 6.x talks to this server.
 

--- a/server.json
+++ b/server.json
@@ -7,13 +7,13 @@
     "url": "https://github.com/IvanMurzak/GameDev-MCP-Server",
     "source": "github"
   },
-  "version": "8.0.1",
+  "version": "8.0.2",
   "packages": [
     {
       "registry_type": "oci",
       "registry_base_url": "https://docker.io",
       "identifier": "aigamedeveloper/mcp-server",
-      "version": "8.0.1",
+      "version": "8.0.2",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
Version bump 8.0.1 → 8.0.2 to release the REDIS_URL-gated Redis session-migration feature merged in #8.

- `<Version>` (csproj) + `server.json` (server + oci package) → 8.0.2 (lockstep)
- README + docs/NUGET.md compatibility tables → 8.0.2 (McpPlugin.Server 6.10.0 / ReflectorNet 5.3.1 unchanged)

On release publish, this ships `aigamedeveloper/mcp-server:8.0.2` (+ `:latest`), the NuGet global tool, and the signed zips. Enables the production cloud MCP-server consolidation onto the shared image.