### PR TITLE
chore: bump ReflectorNet to 5.3.2

### DIFF
--- a/com.IvanMurzak.GameDev.MCP.Server.csproj
+++ b/com.IvanMurzak.GameDev.MCP.Server.csproj
@@ -51,7 +51,7 @@
     with the engine plugins (Unity-MCP / Godot-MCP / Unreal-MCP).
   -->
   <ItemGroup Condition="'$(UseLocalMcpPlugin)' != 'true'">
-    <PackageReference Include="com.IvanMurzak.ReflectorNet" Version="5.3.1" />
+    <PackageReference Include="com.IvanMurzak.ReflectorNet" Version="5.3.2" />
     <PackageReference Include="com.IvanMurzak.McpPlugin.Server" Version="6.11.0" />
   </ItemGroup>
 


### PR DESCRIPTION
Automated downstream bump of `com.IvanMurzak.ReflectorNet` `5.3.1` -> `5.3.2` (ReflectorNet release 1efa1769075d).