### PR TITLE
chore: bump McpPlugin to 6.11.1

### DIFF
--- a/com.IvanMurzak.GameDev.MCP.Server.csproj
+++ b/com.IvanMurzak.GameDev.MCP.Server.csproj
@@ -52,7 +52,7 @@
   -->
   <ItemGroup Condition="'$(UseLocalMcpPlugin)' != 'true'">
     <PackageReference Include="com.IvanMurzak.ReflectorNet" Version="5.3.2" />
-    <PackageReference Include="com.IvanMurzak.McpPlugin.Server" Version="6.11.0" />
+    <PackageReference Include="com.IvanMurzak.McpPlugin.Server" Version="6.11.1" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(UseLocalMcpPlugin)' == 'true'">


### PR DESCRIPTION
Automated downstream bump of `com.IvanMurzak.McpPlugin` `6.11.0` -> `6.11.1` (MCP-Plugin-dotnet release b64bbab104ae).