### PR TITLE
feat(host): consume McpPlugin.Server 7.0 — auth surface + configure subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,16 +109,61 @@ CLI arguments override environment variables.
 | `MCP_PLUGIN_CLIENT_TIMEOUT` | `--plugin-timeout` | `10000` | Plugin → Server connection timeout (ms) |
 | `MCP_PLUGIN_CLIENT_TRANSPORT` | `--client-transport` | `stdio` | Client → Server transport: `stdio` or `streamableHttp` |
 | `MCP_PLUGIN_IDLE_TIMEOUT_SECONDS` | `--idle-timeout-seconds` | `21600` | streamableHttp idle-session eviction window (this host seeds 6h instead of the package default of 600s) |
+| `MCP_AUTH` | `--auth` | transport-dependent (see [Authentication](#authentication)) | Authentication mode: `none` or `oauth` |
+| `MCP_AUTH_ISSUER` | `--auth-issuer` | — | OAuth authorization-server URL (e.g. `https://ai-game.dev`). Required for `oauth` |
+| `MCP_PUBLIC_URL` | `--public-url` | — | This server's canonical public URL / token audience (e.g. `https://ai-game.dev/mcp`). Required for `oauth`; seeds the Origin allow-list |
+| `MCP_BIND` | `--bind` | `loopback` | Bind address: `loopback`, `any` (0.0.0.0), or a specific IP. Hosted deploys behind a proxy set `any`/`0.0.0.0` |
+| `MCP_ALLOWED_ORIGINS` | `--allowed-origins` | — | Comma/semicolon-separated additional allowed browser Origins (added to loopback + the `--public-url` origin) |
 
 Logs are written to `logs/server-log.txt` (and `logs/server-log-error.txt`); in stdio mode console logging is redirected to stderr so stdout stays clean for the MCP JSON stream.
 
+## Authentication
+
+The server is an OAuth 2.1 **resource server**. Two modes:
+
+| Mode | Auth | Default for | Use |
+| --- | --- | --- | --- |
+| `none` | none — single-instance, zero-config | **stdio** | offline / local dev / CI |
+| `oauth` | ES256 JWT validated locally via cached JWKS (with PAT introspection fallback); `401` + `resource_metadata` challenge | **streamableHttp** | signed-in localhost **and** hosted |
+
+- **Transport-conditional default:** `stdio` defaults to `none`. `streamableHttp` defaults to `oauth` **when both `--auth-issuer` and `--public-url` are configured**; otherwise it stays on `none` and logs a warning (so the zero-config `docker run` / `--port 8080` quickstart still works). An explicit `--auth` always wins.
+- **`oauth` requires** `--auth-issuer` (the authorization server, e.g. `https://ai-game.dev`) **and** `--public-url` (this server's canonical audience). Startup fails fast if either is missing while `--auth oauth` is set.
+- **Origin validation** (DNS-rebinding defense) runs in **all** modes: a request with a non-allowed `Origin` gets `403`. Loopback and the `--public-url` origin are allowed by default; add more with `MCP_ALLOWED_ORIGINS`.
+- **Bind** defaults to loopback. Set `--bind any` (or `0.0.0.0`) for a hosted deployment a reverse proxy must reach.
+
+```bash
+# Local, offline (stdio, none) — unchanged zero-config default:
+gamedev-mcp-server --client-transport stdio --port 8080
+
+# Hosted resource server (streamableHttp, oauth), reachable by nginx:
+gamedev-mcp-server --client-transport streamableHttp --port 8080 \
+  --auth oauth --auth-issuer https://ai-game.dev --public-url https://ai-game.dev/mcp \
+  --bind 0.0.0.0
+```
+
+## Configure an AI agent
+
+Write a project-scoped, pinned MCP client config for any supported AI agent from the terminal — no editor UI, no token copy/paste (native OAuth authorize):
+
+```bash
+# Local server, current project:
+gamedev-mcp-server configure --agent claude-code
+# Hosted server:
+gamedev-mcp-server configure --agent codex --url https://ai-game.dev/mcp
+# List agents:
+gamedev-mcp-server configure --help
+```
+
+Each written config is **URL-only** (credentials are never written into project files) and carries the project pin (`…/p/<pin>` path segment) plus, for local servers, the deterministic per-project port — so agent sessions launched in this project folder route strictly to this project's engine. `--agent <id>` accepts any id from `configure --help` (e.g. `claude-code`, `codex`, `cursor`, `vscode-copilot`, …); `--transport stdio` writes a stdio spawn config instead of an HTTP one; `--project <path>` targets a different project root (default: current directory).
+
 ## Compatibility
 
-| GameDev-MCP-Server | McpPlugin.Server | ReflectorNet | Unity-MCP plugin | Godot-MCP addon | Unreal-MCP plugin |
-| --- | --- | --- | --- | --- | --- |
-| 8.0.3 | 6.11.0 | 5.3.1 | ≥ 0.80.x | ≥ 0.3.x | ≥ 0.1.x |
+| GameDev-MCP-Server | McpPlugin.Server | ReflectorNet | Engine plugins |
+| --- | --- | --- | --- |
+| 8.0.3 (released) | 6.11.0 | 5.3.1 | engine plugins on McpPlugin **6.x** |
+| 9.0.0 (upcoming) | 7.0.0-preview.1 | 5.3.2 | engine plugins on McpPlugin **7.x** (Phase 4) |
 
-The engine plugin versions listed pin McpPlugin 6.7.x; any plugin built against McpPlugin 6.x talks to this server. The server version (8.0.3) is deliberately above every per-engine server artifact it replaces so auto-updaters treat it as newer.
+> **Development snapshot.** The `main` branch now builds against **McpPlugin.Server 7.0.0-preview.1** (the mcp-authorize resource-server major) but the `<Version>` / `server.json` version literal is still `8.0.3` — the `9.0.0` version bump and the Docker/zip/dotnet-tool publish are a separate, owner-gated release step run against the McpPlugin 7.0 stable line. The `9.0.0` server needs an engine plugin built on McpPlugin **7.x** (the new instance-metadata handshake + `oauth` mode); older McpPlugin 6.x plugins pair with the released `8.0.3` server line.
 
 ## License
 

--- a/com.IvanMurzak.GameDev.MCP.Server.csproj
+++ b/com.IvanMurzak.GameDev.MCP.Server.csproj
@@ -26,6 +26,11 @@
     <PackageReleaseNotes>First release of the shared GameDev MCP Server as a global dotnet tool</PackageReleaseNotes>
   </PropertyGroup>
 
+  <!-- Expose internal helpers (e.g. ConfigureCommand's pure resolvers) to the test project. -->
+  <ItemGroup>
+    <InternalsVisibleTo Include="GameDev.MCP.Server.Tests" />
+  </ItemGroup>
+
   <!-- Disable static web assets manifests & strip debug symbols for lean Release output -->
   <PropertyGroup Condition="'$(Configuration)' == 'Release'">
     <GenerateStaticWebAssetsManifest>false</GenerateStaticWebAssetsManifest>
@@ -52,11 +57,19 @@
   -->
   <ItemGroup Condition="'$(UseLocalMcpPlugin)' != 'true'">
     <PackageReference Include="com.IvanMurzak.ReflectorNet" Version="5.3.2" />
-    <PackageReference Include="com.IvanMurzak.McpPlugin.Server" Version="6.11.1" />
+    <PackageReference Include="com.IvanMurzak.McpPlugin.Server" Version="7.0.0-preview.1" />
+    <!--
+      Base McpPlugin package: the McpPlugin.Server package does NOT depend on it, but it hosts the
+      shared AI-agent configurator registry (AiAgentConfiguratorRegistry) + ProjectIdentity /
+      ProjectMarker primitives the `configure` subcommand consumes from the terminal. Pinned in
+      lockstep with McpPlugin.Server.
+    -->
+    <PackageReference Include="com.IvanMurzak.McpPlugin" Version="7.0.0-preview.1" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(UseLocalMcpPlugin)' == 'true'">
     <ProjectReference Include="./../MCP-Plugin-dotnet/McpPlugin.Server/McpPlugin.Server.csproj" />
+    <ProjectReference Include="./../MCP-Plugin-dotnet/McpPlugin/McpPlugin.csproj" />
     <ProjectReference Include="./../ReflectorNet/ReflectorNet/ReflectorNet.csproj" />
   </ItemGroup>
 

--- a/docs/NUGET.md
+++ b/docs/NUGET.md
@@ -66,16 +66,25 @@ CLI arguments override environment variables.
 | `MCP_PLUGIN_CLIENT_TIMEOUT` | `--plugin-timeout` | `10000` | Plugin to Server connection timeout (ms) |
 | `MCP_PLUGIN_CLIENT_TRANSPORT` | `--client-transport` | `stdio` | Client to Server transport: `stdio` or `streamableHttp` |
 | `MCP_PLUGIN_IDLE_TIMEOUT_SECONDS` | `--idle-timeout-seconds` | `21600` | streamableHttp idle-session eviction window |
+| `MCP_AUTH` | `--auth` | transport-dependent | Authentication mode: `none` or `oauth` (stdio -> none; http -> oauth when issuer + public-url set) |
+| `MCP_AUTH_ISSUER` | `--auth-issuer` | — | OAuth authorization-server URL. Required for `oauth` |
+| `MCP_PUBLIC_URL` | `--public-url` | — | Canonical public URL / token audience. Required for `oauth` |
+| `MCP_BIND` | `--bind` | `loopback` | Bind address: `loopback`, `any` (0.0.0.0), or a specific IP |
+| `MCP_ALLOWED_ORIGINS` | `--allowed-origins` | — | Additional allowed browser Origins (comma/semicolon-separated) |
 
 In stdio mode console logging is redirected to stderr so stdout stays clean for the MCP JSON stream.
 
+Write a pinned, URL-only MCP client config for an AI agent from the terminal:
+`gamedev-mcp-server configure --agent claude-code` (or `--agent codex --url https://ai-game.dev/mcp`; `configure --help` lists all agents).
+
 ## Compatibility
 
-| GameDev-MCP-Server | McpPlugin.Server | ReflectorNet | Unity-MCP plugin | Godot-MCP addon | Unreal-MCP plugin |
-| --- | --- | --- | --- | --- | --- |
-| 8.0.3 | 6.11.0 | 5.3.1 | >= 0.80.x | >= 0.3.x | >= 0.1.x |
+| GameDev-MCP-Server | McpPlugin.Server | ReflectorNet | Engine plugins |
+| --- | --- | --- | --- |
+| 8.0.3 (released) | 6.11.0 | 5.3.1 | engine plugins on McpPlugin 6.x |
+| 9.0.0 (upcoming) | 7.0.0-preview.1 | 5.3.2 | engine plugins on McpPlugin 7.x (Phase 4) |
 
-Any engine plugin built against McpPlugin 6.x talks to this server.
+The `main` branch builds against McpPlugin.Server 7.0.0-preview.1 (the OAuth resource-server major); the `9.0.0` version bump + publish is a separate owner-gated release step. Older McpPlugin 6.x engine plugins pair with the released `8.0.3` server line.
 
 ## Links
 

--- a/server.json
+++ b/server.json
@@ -43,6 +43,47 @@
           ],
           "is_required": false,
           "is_secret": false
+        },
+        {
+          "name": "MCP_AUTH",
+          "description": "Authentication mode: none or oauth. Default depends on transport: stdio -> none (offline/local/CI), streamableHttp -> oauth when MCP_AUTH_ISSUER + MCP_PUBLIC_URL are set, otherwise none. oauth validates ES256 JWTs (via cached JWKS) issued by MCP_AUTH_ISSUER, audienced to MCP_PUBLIC_URL.",
+          "format": "string",
+          "default": "none",
+          "enum": [
+            "none",
+            "oauth"
+          ],
+          "is_required": false,
+          "is_secret": false
+        },
+        {
+          "name": "MCP_AUTH_ISSUER",
+          "description": "OAuth authorization-server URL (e.g. https://ai-game.dev). Required when MCP_AUTH=oauth.",
+          "format": "string",
+          "is_required": false,
+          "is_secret": false
+        },
+        {
+          "name": "MCP_PUBLIC_URL",
+          "description": "This server's canonical public resource URL (its token audience, e.g. https://ai-game.dev/mcp). Required when MCP_AUTH=oauth; also seeds the Origin allow-list.",
+          "format": "string",
+          "is_required": false,
+          "is_secret": false
+        },
+        {
+          "name": "MCP_BIND",
+          "description": "Network bind address: loopback (default), any (0.0.0.0), or a specific IP. Hosted deploys reachable by a reverse proxy set MCP_BIND=0.0.0.0.",
+          "format": "string",
+          "default": "loopback",
+          "is_required": false,
+          "is_secret": false
+        },
+        {
+          "name": "MCP_ALLOWED_ORIGINS",
+          "description": "Comma/semicolon-separated additional allowed Origins for browser clients (in addition to loopback + the MCP_PUBLIC_URL origin). Avoids a blanket wildcard on credentialed paths.",
+          "format": "string",
+          "is_required": false,
+          "is_secret": false
         }
       ]
     }

--- a/src/Configure/ConfigureCommand.cs
+++ b/src/Configure/ConfigureCommand.cs
@@ -215,6 +215,7 @@ namespace com.IvanMurzak.GameDev.MCP.Server.Configure
         {
             if (!string.IsNullOrWhiteSpace(rawAuth)
                 && Enum.TryParse<Consts.MCP.Server.AuthOption>(rawAuth.Trim(), ignoreCase: true, out var explicitOption)
+                && Enum.IsDefined(typeof(Consts.MCP.Server.AuthOption), explicitOption)
                 && explicitOption != Consts.MCP.Server.AuthOption.unknown)
                 return explicitOption;
 

--- a/src/Configure/ConfigureCommand.cs
+++ b/src/Configure/ConfigureCommand.cs
@@ -1,0 +1,260 @@
+/*
+┌───────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                      │
+│  Repository: GitHub (https://github.com/IvanMurzak/GameDev-MCP-Server)    │
+│  Copyright (c) 2026 Ivan Murzak                                           │
+│  Licensed under the Apache License, Version 2.0.                          │
+│  See the LICENSE file in the project root for more information.           │
+└───────────────────────────────────────────────────────────────────────────┘
+*/
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using com.IvanMurzak.McpPlugin.AgentConfig;  // AiAgentConfigurator(Registry|Settings), AiAgentConfig, ConnectionMode, ProjectIdentity, ProjectMarker
+using com.IvanMurzak.McpPlugin.Common;       // Consts (+ nested Consts.MCP.Server.AuthOption)
+using com.IvanMurzak.McpPlugin.Common.Utils; // ArgsUtils
+
+namespace com.IvanMurzak.GameDev.MCP.Server.Configure
+{
+    /// <summary>
+    /// Terminal subcommand: <c>gamedev-mcp-server configure --agent &lt;id&gt; [--url &lt;url&gt;]
+    /// [--transport stdio|http] [--project &lt;path&gt;]</c>.
+    /// <para>
+    /// Exposes the shared AI-agent configurator registry
+    /// (<see cref="AiAgentConfiguratorRegistry"/>) from the terminal (design 06 §"Engine CLIs become
+    /// full installers", D12) so agent-first users can write any of the shipped client configs with one
+    /// command without touching the editor UI. Every written config is <b>project-scoped and pinned</b>:
+    /// the URL carries the D14 <c>/p/&lt;pin&gt;</c> path segment and the D15 deterministic per-project
+    /// port, both derived by the shared <see cref="ProjectIdentity"/> from the (normalized) project root
+    /// plus the committable <see cref="ProjectMarker"/> (<c>.ai-game-dev/project.json</c>). Credentials
+    /// are never written into the config (URL-only default, D11).
+    /// </para>
+    /// The subcommand resolves and writes the config, then exits WITHOUT starting the server.
+    /// </summary>
+    public static class ConfigureCommand
+    {
+        public const string CommandName = "configure";
+
+        private const string DefaultLocalHost = "http://localhost";
+        private const string ServerExecutableName = "gamedev-mcp-server";
+        private const string DockerImage = "aigamedeveloper/mcp-server";
+        private const int DefaultPluginTimeoutMs = 10000;
+
+        /// <summary>True when the process was launched as <c>gamedev-mcp-server configure …</c>.</summary>
+        public static bool IsInvocation(string[]? args)
+            => args is { Length: > 0 }
+               && string.Equals(args[0], CommandName, StringComparison.OrdinalIgnoreCase);
+
+        /// <summary>
+        /// The resolved, not-yet-written plan for one <c>configure</c> invocation. Splitting the
+        /// resolution from the on-disk write keeps the interesting logic (agent lookup, transport,
+        /// connection-mode, pinned URL) unit-testable without mutating any real config file.
+        /// </summary>
+        public sealed class Plan
+        {
+            public AiAgentConfigurator Configurator { get; }
+            public AgentConfiguratorSettings Settings { get; }
+            public AiAgentConfig Config { get; }
+            public Consts.MCP.Server.TransportMethod Transport { get; }
+
+            public Plan(
+                AiAgentConfigurator configurator,
+                AgentConfiguratorSettings settings,
+                AiAgentConfig config,
+                Consts.MCP.Server.TransportMethod transport)
+            {
+                Configurator = configurator;
+                Settings = settings;
+                Config = config;
+                Transport = transport;
+            }
+
+            public string AgentId => Configurator.AgentId;
+            public string AgentName => Configurator.AgentName;
+            public string ProjectPin => Settings.ProjectPin;
+            public int ResolvedPort => Settings.ResolvedPort;
+            public string ConfigPath => Config.ConfigPath;
+            public string ExpectedFileContent => Config.ExpectedFileContent;
+        }
+
+        /// <summary>Thrown for user-facing configuration errors (unknown agent, bad transport, …).</summary>
+        public sealed class ConfigureException : Exception
+        {
+            public ConfigureException(string message) : base(message) { }
+        }
+
+        /// <summary>
+        /// Resolve a <see cref="Plan"/> from parsed <c>configure</c> options. Reads the project marker
+        /// from disk (for a port override / server target) but writes nothing.
+        /// </summary>
+        public static Plan BuildPlan(IReadOnlyDictionary<string, string> options, string executableFullPath, string serverVersion)
+        {
+            var agentId = Get(options, "agent")?.Trim();
+            if (string.IsNullOrEmpty(agentId))
+                throw new ConfigureException(
+                    "configure requires --agent <id>. Available agents: " + string.Join(", ", AiAgentConfiguratorRegistry.GetAgentIds()));
+
+            var configurator = AiAgentConfiguratorRegistry.GetByAgentId(agentId);
+            if (configurator == null)
+                throw new ConfigureException(
+                    $"Unknown --agent '{agentId}'. Available agents: " + string.Join(", ", AiAgentConfiguratorRegistry.GetAgentIds()));
+
+            var transport = ResolveTransport(Get(options, "transport"));
+
+            var projectRoot = ResolveProjectRoot(Get(options, "project"));
+
+            var url = Get(options, "url")?.Trim();
+            var host = string.IsNullOrEmpty(url) ? DefaultLocalHost : url;
+            var connectionMode = ResolveConnectionMode(host);
+
+            // URL-only default (D11): the golden path never writes a credential into a project file.
+            // Local => none (offline), Cloud => oauth (native authorize). An explicit --auth overrides.
+            var authOption = ResolveAuthOption(Get(options, "auth"), connectionMode);
+
+            // The deterministic per-project port (D15) comes from ProjectIdentity, sourced from the
+            // committable project marker's optional portOverride. Pass it as `port` so the settings'
+            // Port matches its derived ResolvedPort/pin exactly.
+            var identity = ProjectIdentity.Derive(projectRoot, ProjectMarker.Read(projectRoot));
+
+            var settings = AgentConfiguratorSettings.CreateForHost(
+                projectRootPath: projectRoot,
+                executableFullPath: executableFullPath,
+                port: identity.Port,
+                timeoutMs: DefaultPluginTimeoutMs,
+                host: host,
+                token: null,
+                connectionMode: connectionMode,
+                authOption: authOption,
+                serverExecutableName: ServerExecutableName,
+                serverVersion: serverVersion,
+                dockerImage: DockerImage);
+
+            var config = transport == Consts.MCP.Server.TransportMethod.stdio
+                ? configurator.GetStdioConfig(settings)
+                : configurator.GetHttpConfig(settings);
+
+            return new Plan(configurator, settings, config, transport);
+        }
+
+        /// <summary>Entry point: parse args, build the plan, write the config, print a summary.</summary>
+        public static int Run(string[] args)
+        {
+            try
+            {
+                // Drop the leading "configure" token; parse the rest with the same parser DataArguments uses.
+                var rest = args.Skip(1).ToArray();
+                var options = ArgsUtils.ParseLineArguments(rest);
+
+                if (options.ContainsKey("help") || options.ContainsKey("h"))
+                {
+                    PrintUsage();
+                    return 0;
+                }
+
+                var plan = BuildPlan(options, ResolveExecutablePath(), ResolveServerVersion());
+
+                var ok = plan.Config.Configure();
+                if (!ok)
+                {
+                    Console.Error.WriteLine($"Failed to write {plan.AgentName} configuration to {plan.ConfigPath}.");
+                    return 1;
+                }
+
+                Console.WriteLine($"Configured {plan.AgentName} ({plan.AgentId}).");
+                Console.WriteLine($"  transport : {plan.Transport}");
+                Console.WriteLine($"  project   : {plan.Settings.ProjectRootPath}");
+                Console.WriteLine($"  pin       : {plan.ProjectPin}");
+                if (plan.Settings.ConnectionMode == ConnectionMode.Local)
+                    Console.WriteLine($"  port      : {plan.ResolvedPort}");
+                Console.WriteLine($"  config    : {plan.ConfigPath}");
+                return 0;
+            }
+            catch (ConfigureException ex)
+            {
+                Console.Error.WriteLine(ex.Message);
+                return 2;
+            }
+            catch (Exception ex)
+            {
+                Console.Error.WriteLine("configure failed: " + ex.Message);
+                return 1;
+            }
+        }
+
+        // --- helpers ------------------------------------------------------------------------------
+
+        private static string? Get(IReadOnlyDictionary<string, string> options, string key)
+            => options.TryGetValue(key, out var value) ? value : null;
+
+        internal static Consts.MCP.Server.TransportMethod ResolveTransport(string? raw)
+        {
+            if (string.IsNullOrWhiteSpace(raw))
+                return Consts.MCP.Server.TransportMethod.streamableHttp; // http default
+
+            var trimmed = raw.Trim();
+            if (string.Equals(trimmed, "http", StringComparison.OrdinalIgnoreCase)
+                || string.Equals(trimmed, "streamableHttp", StringComparison.OrdinalIgnoreCase))
+                return Consts.MCP.Server.TransportMethod.streamableHttp;
+            if (string.Equals(trimmed, "stdio", StringComparison.OrdinalIgnoreCase))
+                return Consts.MCP.Server.TransportMethod.stdio;
+
+            throw new ConfigureException($"Invalid --transport '{raw}'. Use 'http' or 'stdio'.");
+        }
+
+        internal static ConnectionMode ResolveConnectionMode(string host)
+        {
+            if (Uri.TryCreate(host, UriKind.Absolute, out var uri) && !uri.IsLoopback)
+                return ConnectionMode.Cloud;
+            return ConnectionMode.Local;
+        }
+
+        internal static Consts.MCP.Server.AuthOption ResolveAuthOption(string? rawAuth, ConnectionMode connectionMode)
+        {
+            if (!string.IsNullOrWhiteSpace(rawAuth)
+                && Enum.TryParse<Consts.MCP.Server.AuthOption>(rawAuth.Trim(), ignoreCase: true, out var explicitOption)
+                && explicitOption != Consts.MCP.Server.AuthOption.unknown)
+                return explicitOption;
+
+            return connectionMode == ConnectionMode.Cloud
+                ? Consts.MCP.Server.AuthOption.oauth
+                : Consts.MCP.Server.AuthOption.none;
+        }
+
+        private static string ResolveProjectRoot(string? raw)
+        {
+            var root = string.IsNullOrWhiteSpace(raw) ? Environment.CurrentDirectory : raw.Trim();
+            return Path.GetFullPath(root);
+        }
+
+        private static string ResolveExecutablePath()
+            => Environment.ProcessPath ?? Path.Combine(AppContext.BaseDirectory, ServerExecutableName);
+
+        private static string ResolveServerVersion()
+        {
+            var informational = Assembly.GetExecutingAssembly()
+                .GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion;
+            if (!string.IsNullOrEmpty(informational))
+            {
+                // Strip any "+<git-sha>" build-metadata suffix.
+                var plus = informational.IndexOf('+');
+                return plus >= 0 ? informational.Substring(0, plus) : informational;
+            }
+            return Assembly.GetExecutingAssembly().GetName().Version?.ToString(3) ?? "8.0.0";
+        }
+
+        private static void PrintUsage()
+        {
+            Console.WriteLine("Usage: gamedev-mcp-server configure --agent <id> [--url <url>] [--transport stdio|http] [--project <path>]");
+            Console.WriteLine();
+            Console.WriteLine("Writes a project-scoped, pinned MCP client config for the chosen AI agent.");
+            Console.WriteLine("Credentials are never written into the config (URL-only; native authorize).");
+            Console.WriteLine();
+            Console.WriteLine("Available agents:");
+            foreach (var configurator in AiAgentConfiguratorRegistry.All)
+                Console.WriteLine($"  {configurator.AgentId,-20} {configurator.AgentName}");
+        }
+    }
+}

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -11,6 +11,8 @@
 using System;
 using System.Text.Json;
 using System.Threading.Tasks;
+using com.IvanMurzak.GameDev.MCP.Server.Configure;
+using com.IvanMurzak.GameDev.MCP.Server.Startup;
 using com.IvanMurzak.McpPlugin.Common;
 using com.IvanMurzak.McpPlugin.Common.Utils;
 using com.IvanMurzak.McpPlugin.Server;
@@ -29,8 +31,14 @@ namespace com.IvanMurzak.GameDev.MCP.Server
 {
     public class Program
     {
-        public static async Task Main(string[] args)
+        public static async Task<int> Main(string[] args)
         {
+            // Subcommand dispatch: `gamedev-mcp-server configure --agent <id> [--url ...]` writes an MCP
+            // client config from the terminal using the shared configurator registry, then exits WITHOUT
+            // starting the server. Handled first so it never boots Kestrel / NLog server logging.
+            if (ConfigureCommand.IsInvocation(args))
+                return ConfigureCommand.Run(args);
+
             // Configure NLog
             LogManager.Setup().LoadConfigurationFromFile("NLog.config");
 
@@ -41,6 +49,28 @@ namespace com.IvanMurzak.GameDev.MCP.Server
             // explicit MCP_PLUGIN_IDLE_TIMEOUT_SECONDS or --idle-timeout-seconds still overrides this.
             if (string.IsNullOrEmpty(Environment.GetEnvironmentVariable(Consts.MCP.Server.Env.IdleTimeoutSeconds)))
                 Environment.SetEnvironmentVariable(Consts.MCP.Server.Env.IdleTimeoutSeconds, "21600"); // 6 hours
+
+            // Transport-conditional authentication default (mcp-authorize, design 02 §"modes"):
+            // stdio => none, streamableHttp => oauth. DataArguments defaults auth to `none` for BOTH
+            // transports (it cannot know the host policy), so the host seeds the http default here.
+            // Mirroring the idle-timeout seed above, we only SEED the env var — never override an
+            // explicit choice — and DataArguments re-parses it below. oauth mode REQUIRES --auth-issuer
+            // AND --public-url (the shared AccountMcpStrategy.Validate throws otherwise), so http only
+            // defaults to oauth when both are configured; without them it stays on `none` with a loud
+            // warning rather than crashing the documented bare-run quickstart. See HostAuthDefaults.
+            var authProbe = new DataArguments(args);
+            var authDecision = HostAuthDefaults.Decide(
+                authProbe.ClientTransport,
+                HostAuthDefaults.IsAuthExplicitlySet(args),
+                hasAuthIssuer: !string.IsNullOrWhiteSpace(authProbe.AuthIssuer),
+                hasPublicUrl: !string.IsNullOrWhiteSpace(authProbe.PublicUrl));
+
+            if (authDecision == HostAuthDefaults.Decision.DefaultHttpToOauth)
+                Environment.SetEnvironmentVariable(
+                    Consts.MCP.Server.Env.Auth,
+                    Consts.MCP.Server.AuthOption.oauth.ToString());
+
+            var httpUnauthenticatedFallback = authDecision == HostAuthDefaults.Decision.DefaultHttpToNoneWithWarning;
 
             var dataArguments = new DataArguments(args);
 
@@ -81,6 +111,26 @@ namespace com.IvanMurzak.GameDev.MCP.Server
                 var mcpServerBuilder = builder.Services
                     .WithMcpServer(dataArguments, logger)
                     .WithMcpPluginServer(dataArguments);
+
+                // Additional configurable Origin allow-list (b2 carry-forward / design 02 §Origin
+                // validation). The library default admits loopback + the --public-url origin only. When
+                // MCP_ALLOWED_ORIGINS (or --allowed-origins) is set, REPLACE the default
+                // OriginValidationOptions singleton with one that also admits the configured origins, so
+                // a hosted browser client on a different origin works without a blanket `*` on
+                // credentialed paths. Registered AFTER WithMcpPluginServer so this instance wins on
+                // resolution. Unset => the library default (already registered) stands untouched.
+                var rawAllowedOrigins = Environment.GetEnvironmentVariable(OriginAllowList.EnvVar);
+                var parsedArgs = ArgsUtils.ParseLineArguments(args);
+                if (parsedArgs.TryGetValue(OriginAllowList.ArgName, out var argAllowedOrigins)
+                    && !string.IsNullOrWhiteSpace(argAllowedOrigins))
+                    rawAllowedOrigins = argAllowedOrigins;
+
+                if (OriginAllowList.TryBuildOptions(dataArguments, rawAllowedOrigins, out var originOptions)
+                    && originOptions != null)
+                {
+                    builder.Services.AddSingleton(originOptions);
+                    logger.Info($"Origin allow-list extended with {originOptions.AllowedOrigins.Count} configured origin(s) (plus loopback).");
+                }
 
                 // Issue #70 — Option B: when REDIS_URL is set, plug Redis into the SDK's
                 // session-migration + SSE event-store hooks so sessions survive a restart.
@@ -136,10 +186,12 @@ namespace com.IvanMurzak.GameDev.MCP.Server
 
                 // builder.WebHost.UseUrls(Consts.Hub.DefaultEndpoint);
 
-                logger.Info($"Start listening on port: {dataArguments.Port}");
+                logger.Info($"Start listening on port: {dataArguments.Port} (bind: {dataArguments.Bind ?? "loopback"})");
 
-                // Bind IPv4 and IPv6 separately to avoid dual-stack socket issues on macOS.
-                builder.WebHost.UseKestrelForMcpPlugin(dataArguments.Port);
+                // Bind IPv4 and IPv6 separately to avoid dual-stack socket issues on macOS. The bind
+                // address (D8: default loopback; --bind/MCP_BIND=any|0.0.0.0|<ip> for LAN/hosted deploys
+                // that nginx must reach) is forwarded to the library's bind-aware Kestrel overload.
+                builder.WebHost.UseKestrelForMcpPlugin(dataArguments.Port, dataArguments.Bind);
 
                 var app = builder.Build();
 
@@ -149,6 +201,18 @@ namespace com.IvanMurzak.GameDev.MCP.Server
                         "REDIS_URL is not set — MCP sessions will NOT survive a server restart. "
                         + "Configure Redis to enable Option B (issue #70).");
                 }
+
+                if (httpUnauthenticatedFallback)
+                {
+                    app.Logger.LogWarning(
+                        "streamableHttp is running WITHOUT authentication (auth=none) because --auth-issuer/--public-url "
+                        + "were not configured. For a network-exposed deployment set --auth oauth with --auth-issuer and "
+                        + "--public-url (see README § Authentication). Pass --auth none explicitly to silence this warning.");
+                }
+
+                app.Logger.LogInformation(
+                    "MCP auth mode: {AuthMode} (transport: {Transport}, bind: {Bind}).",
+                    dataArguments.Authorization, dataArguments.ClientTransport, dataArguments.Bind ?? "loopback");
 
                 // Middleware ----------------------------------------------------------------
                 // ---------------------------------------------------------------------------
@@ -203,6 +267,7 @@ namespace com.IvanMurzak.GameDev.MCP.Server
                 #endregion
 
                 await app.RunAsync();
+                return 0;
             }
             catch (Exception ex)
             {

--- a/src/Startup/HostAuthDefaults.cs
+++ b/src/Startup/HostAuthDefaults.cs
@@ -1,0 +1,92 @@
+/*
+┌───────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                      │
+│  Repository: GitHub (https://github.com/IvanMurzak/GameDev-MCP-Server)    │
+│  Copyright (c) 2026 Ivan Murzak                                           │
+│  Licensed under the Apache License, Version 2.0.                          │
+│  See the LICENSE file in the project root for more information.           │
+└───────────────────────────────────────────────────────────────────────────┘
+*/
+
+using System;
+using com.IvanMurzak.McpPlugin.Common;
+using com.IvanMurzak.McpPlugin.Common.Utils;
+
+namespace com.IvanMurzak.GameDev.MCP.Server.Startup
+{
+    /// <summary>
+    /// Host-level policy for the transport-conditional authentication default introduced with the
+    /// mcp-authorize redesign (design 02 §"GameDev-MCP-Server modes"): <b>stdio defaults to
+    /// <c>none</c></b> (offline / local dev / CI) and <b>streamableHttp defaults to <c>oauth</c></b>
+    /// (the authenticated resource-server path).
+    /// <para>
+    /// The shared <see cref="DataArguments"/> parser defaults <see cref="DataArguments.Authorization"/>
+    /// to <see cref="Consts.MCP.Server.AuthOption.none"/> for BOTH transports (it cannot know the
+    /// host's default policy), so this class decides whether the host should upgrade an unset http auth
+    /// to <c>oauth</c>. It is a pure decision so the policy is unit-testable without booting Kestrel.
+    /// </para>
+    /// <para>
+    /// Guard rail: <c>oauth</c> mode requires <c>--auth-issuer</c> AND <c>--public-url</c> — the shared
+    /// library's <c>AccountMcpStrategy.Validate</c> throws at startup when either is missing. So the
+    /// host defaults http to <c>oauth</c> ONLY when both are present; otherwise it leaves http on
+    /// <c>none</c> and emits a loud warning rather than crashing the documented bare-run quickstart
+    /// (<c>docker run … aigamedeveloper/mcp-server</c> / <c>gamedev-mcp-server --port 8080</c>). An
+    /// explicit <c>--auth</c>/<c>--authorization</c> (or <c>MCP_AUTH</c>/<c>MCP_AUTHORIZATION</c>) always
+    /// wins and is left untouched.
+    /// </para>
+    /// </summary>
+    public static class HostAuthDefaults
+    {
+        public enum Decision
+        {
+            /// <summary>Explicit auth was given, or transport is stdio — leave DataArguments' value as-is.</summary>
+            LeaveAsConfigured,
+
+            /// <summary>Http with issuer + public-url present — seed the http default of <c>oauth</c>.</summary>
+            DefaultHttpToOauth,
+
+            /// <summary>Http but oauth is not configurable — stay on <c>none</c> and warn the operator.</summary>
+            DefaultHttpToNoneWithWarning
+        }
+
+        /// <summary>
+        /// True when the operator explicitly chose an auth mode via env (<c>MCP_AUTH</c> /
+        /// <c>MCP_AUTHORIZATION</c>) or CLI (<c>--auth</c> / <c>--authorization</c>). The library
+        /// arg parser (<see cref="ArgsUtils.ParseLineArguments"/>) is reused so key detection matches
+        /// exactly how <see cref="DataArguments"/> itself reads the args.
+        /// </summary>
+        public static bool IsAuthExplicitlySet(string[] args)
+        {
+            if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable(Consts.MCP.Server.Env.Auth)))
+                return true;
+            if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable(Consts.MCP.Server.Env.Authorization)))
+                return true;
+
+            var parsed = ArgsUtils.ParseLineArguments(args ?? Array.Empty<string>());
+            return parsed.ContainsKey(Consts.MCP.Server.Args.Auth)
+                || parsed.ContainsKey(Consts.MCP.Server.Args.Authorization);
+        }
+
+        /// <summary>
+        /// Decide the host's auth default for the resolved transport. See the class remarks for the
+        /// full policy. Pure — no side effects.
+        /// </summary>
+        public static Decision Decide(
+            Consts.MCP.Server.TransportMethod transport,
+            bool authExplicitlySet,
+            bool hasAuthIssuer,
+            bool hasPublicUrl)
+        {
+            if (authExplicitlySet)
+                return Decision.LeaveAsConfigured;
+
+            // stdio (and the defensive unknown case) keep DataArguments' `none` default.
+            if (transport != Consts.MCP.Server.TransportMethod.streamableHttp)
+                return Decision.LeaveAsConfigured;
+
+            return (hasAuthIssuer && hasPublicUrl)
+                ? Decision.DefaultHttpToOauth
+                : Decision.DefaultHttpToNoneWithWarning;
+        }
+    }
+}

--- a/src/Startup/OriginAllowList.cs
+++ b/src/Startup/OriginAllowList.cs
@@ -62,6 +62,14 @@ namespace com.IvanMurzak.GameDev.MCP.Server.Startup
         /// Loopback is handled separately by <see cref="OriginValidationOptions.AllowLoopback"/>.
         /// </summary>
         public static IReadOnlyCollection<string> BuildAllowedOrigins(string? publicUrl, string? rawAllowedOrigins)
+            => Merge(publicUrl, ParseOrigins(rawAllowedOrigins));
+
+        /// <summary>
+        /// Merge the normalized public-url origin (if any) with an already-parsed set of extra origins.
+        /// Shared by <see cref="BuildAllowedOrigins"/> and <see cref="TryBuildOptions"/> so the raw list
+        /// is parsed exactly once per invocation.
+        /// </summary>
+        private static IReadOnlyCollection<string> Merge(string? publicUrl, IReadOnlyList<string> extraOrigins)
         {
             var set = new HashSet<string>(StringComparer.Ordinal);
 
@@ -69,7 +77,7 @@ namespace com.IvanMurzak.GameDev.MCP.Server.Startup
             if (!string.IsNullOrEmpty(publicOrigin))
                 set.Add(publicOrigin);
 
-            foreach (var origin in ParseOrigins(rawAllowedOrigins))
+            foreach (var origin in extraOrigins)
                 set.Add(origin);
 
             return set;
@@ -83,11 +91,12 @@ namespace com.IvanMurzak.GameDev.MCP.Server.Startup
         public static bool TryBuildOptions(DataArguments dataArguments, string? rawAllowedOrigins, out OriginValidationOptions? options)
         {
             options = null;
-            if (ParseOrigins(rawAllowedOrigins).Count == 0)
+            var extraOrigins = ParseOrigins(rawAllowedOrigins);
+            if (extraOrigins.Count == 0)
                 return false;
 
             options = new OriginValidationOptions(
-                BuildAllowedOrigins(dataArguments.PublicUrl, rawAllowedOrigins),
+                Merge(dataArguments.PublicUrl, extraOrigins),
                 allowLoopback: true);
             return true;
         }

--- a/src/Startup/OriginAllowList.cs
+++ b/src/Startup/OriginAllowList.cs
@@ -1,0 +1,95 @@
+/*
+┌───────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                      │
+│  Repository: GitHub (https://github.com/IvanMurzak/GameDev-MCP-Server)    │
+│  Copyright (c) 2026 Ivan Murzak                                           │
+│  Licensed under the Apache License, Version 2.0.                          │
+│  See the LICENSE file in the project root for more information.           │
+└───────────────────────────────────────────────────────────────────────────┘
+*/
+
+using System;
+using System.Collections.Generic;
+using com.IvanMurzak.McpPlugin.Common.Utils;      // DataArguments
+using com.IvanMurzak.McpPlugin.Server.Auth.OAuth; // UrlNormalization
+using com.IvanMurzak.McpPlugin.Server.Security;    // OriginValidationOptions
+
+namespace com.IvanMurzak.GameDev.MCP.Server.Startup
+{
+    /// <summary>
+    /// Host surface for an <b>additional, configurable Origin allow-list</b> (carry-forward from b2 /
+    /// design 02 §"Origin validation"). The shared library's default admits only loopback origins plus
+    /// the <c>--public-url</c> origin (<c>OriginValidationOptions.FromArguments</c>) — correct for the
+    /// hosted API and same-origin browser clients, but a hosted deployment that serves a browser client
+    /// from a DIFFERENT origin (e.g. a first-party web console) needs to allow that origin WITHOUT
+    /// weakening the guard to a blanket <c>*</c> on credentialed paths.
+    /// <para>
+    /// The host reads <c>MCP_ALLOWED_ORIGINS</c> / <c>--allowed-origins</c> (comma- or
+    /// semicolon-separated) and, when set, registers a replacement <see cref="OriginValidationOptions"/>
+    /// that keeps loopback + the public-url origin and ADDS the configured origins. Origins are
+    /// normalized with the library's own <see cref="UrlNormalization.NormalizeOrigin"/> so they match
+    /// the middleware's ordinal comparison exactly. When unset, the library default is left untouched.
+    /// </para>
+    /// </summary>
+    public static class OriginAllowList
+    {
+        public const string EnvVar = "MCP_ALLOWED_ORIGINS";
+        public const string ArgName = "allowed-origins";
+
+        /// <summary>
+        /// Parse a comma/semicolon-separated origin list into the normalized, de-duplicated set the
+        /// middleware compares against. Malformed entries are dropped (they could never match anyway).
+        /// </summary>
+        public static IReadOnlyList<string> ParseOrigins(string? raw)
+        {
+            var result = new List<string>();
+            if (string.IsNullOrWhiteSpace(raw))
+                return result;
+
+            var seen = new HashSet<string>(StringComparer.Ordinal);
+            foreach (var part in raw.Split(new[] { ',', ';' }, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+            {
+                var normalized = UrlNormalization.NormalizeOrigin(part);
+                if (!string.IsNullOrEmpty(normalized) && seen.Add(normalized))
+                    result.Add(normalized);
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        /// The merged allow-list = normalized public-url origin (if any) + the configured extra origins.
+        /// Loopback is handled separately by <see cref="OriginValidationOptions.AllowLoopback"/>.
+        /// </summary>
+        public static IReadOnlyCollection<string> BuildAllowedOrigins(string? publicUrl, string? rawAllowedOrigins)
+        {
+            var set = new HashSet<string>(StringComparer.Ordinal);
+
+            var publicOrigin = UrlNormalization.NormalizeOrigin(publicUrl);
+            if (!string.IsNullOrEmpty(publicOrigin))
+                set.Add(publicOrigin);
+
+            foreach (var origin in ParseOrigins(rawAllowedOrigins))
+                set.Add(origin);
+
+            return set;
+        }
+
+        /// <summary>
+        /// Build a replacement <see cref="OriginValidationOptions"/> when extra origins are configured;
+        /// returns false (and null) when <paramref name="rawAllowedOrigins"/> yields nothing, so the
+        /// caller can leave the library's default registration in place.
+        /// </summary>
+        public static bool TryBuildOptions(DataArguments dataArguments, string? rawAllowedOrigins, out OriginValidationOptions? options)
+        {
+            options = null;
+            if (ParseOrigins(rawAllowedOrigins).Count == 0)
+                return false;
+
+            options = new OriginValidationOptions(
+                BuildAllowedOrigins(dataArguments.PublicUrl, rawAllowedOrigins),
+                allowLoopback: true);
+            return true;
+        }
+    }
+}

--- a/tests/GameDev.MCP.Server.Tests/ConfigureCommandTests.cs
+++ b/tests/GameDev.MCP.Server.Tests/ConfigureCommandTests.cs
@@ -1,0 +1,187 @@
+/*
+┌───────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                      │
+│  Repository: GitHub (https://github.com/IvanMurzak/GameDev-MCP-Server)    │
+│  Copyright (c) 2026 Ivan Murzak                                           │
+│  Licensed under the Apache License, Version 2.0.                          │
+│  See the LICENSE file in the project root for more information.           │
+└───────────────────────────────────────────────────────────────────────────┘
+*/
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using com.IvanMurzak.GameDev.MCP.Server.Configure;
+using com.IvanMurzak.McpPlugin.AgentConfig;
+using com.IvanMurzak.McpPlugin.Common;
+using Xunit;
+
+namespace com.IvanMurzak.GameDev.MCP.Server.Tests
+{
+    /// <summary>
+    /// Covers the `configure --agent &lt;id&gt;` subcommand (design 06 D12): it resolves a configurator
+    /// from the shared registry, derives the D14 pin + D15 port, and writes a project-scoped, pinned,
+    /// URL-only config. Claude Code (<c>.mcp.json</c>) and Codex (<c>.codex/config.toml</c>) are both
+    /// project-scoped, so the write tests are sandboxed to a temp project root.
+    /// </summary>
+    public class ConfigureCommandTests
+    {
+        private const string FakeExe = "/opt/gamedev-mcp-server/gamedev-mcp-server";
+        private const string FakeVersion = "9.0.0";
+
+        [Fact]
+        public void IsInvocation_ConfigureFirst_True()
+        {
+            Assert.True(ConfigureCommand.IsInvocation(new[] { "configure", "--agent", "claude-code" }));
+            Assert.True(ConfigureCommand.IsInvocation(new[] { "CONFIGURE" }));
+        }
+
+        [Fact]
+        public void IsInvocation_NotConfigure_False()
+        {
+            Assert.False(ConfigureCommand.IsInvocation(Array.Empty<string>()));
+            Assert.False(ConfigureCommand.IsInvocation(new[] { "--port", "8080" }));
+        }
+
+        [Fact]
+        public void BuildPlan_ClaudeCodeHttpLocal_WritesPinnedProjectScopedConfig()
+        {
+            RunInTempProject(projectRoot =>
+            {
+                var plan = ConfigureCommand.BuildPlan(
+                    new Dictionary<string, string> { ["agent"] = "claude-code", ["project"] = projectRoot },
+                    FakeExe, FakeVersion);
+
+                Assert.Equal("claude-code", plan.AgentId);
+                Assert.Equal(Consts.MCP.Server.TransportMethod.streamableHttp, plan.Transport);
+                Assert.Equal(ConnectionMode.Local, plan.Settings.ConnectionMode);
+
+                // D14 pin = 8 hex chars; D15 port in the deterministic 20000-29999 range.
+                Assert.Equal(8, plan.ProjectPin.Length);
+                Assert.InRange(plan.ResolvedPort, ProjectIdentity.MinPort, ProjectIdentity.MaxPort);
+
+                // Config is project-scoped (.mcp.json under the project root) and carries the pinned URL.
+                Assert.Equal(Path.Combine(projectRoot, ".mcp.json"), plan.ConfigPath);
+                Assert.Contains("/p/" + plan.ProjectPin, plan.ExpectedFileContent);
+
+                // The write lands in the temp project root (safe) — assert it actually happened.
+                Assert.True(plan.Config.Configure());
+                Assert.True(File.Exists(plan.ConfigPath));
+                Assert.Contains(plan.ProjectPin, File.ReadAllText(plan.ConfigPath));
+            });
+        }
+
+        [Fact]
+        public void BuildPlan_CodexHttpLocal_UsesPinnedTomlConfig()
+        {
+            RunInTempProject(projectRoot =>
+            {
+                var plan = ConfigureCommand.BuildPlan(
+                    new Dictionary<string, string> { ["agent"] = "codex", ["project"] = projectRoot },
+                    FakeExe, FakeVersion);
+
+                Assert.Equal("codex", plan.AgentId);
+                Assert.Equal(Path.Combine(projectRoot, ".codex", "config.toml"), plan.ConfigPath);
+                Assert.Contains("/p/" + plan.ProjectPin, plan.ExpectedFileContent);
+
+                Assert.True(plan.Config.Configure());
+                Assert.True(File.Exists(plan.ConfigPath));
+            });
+        }
+
+        [Fact]
+        public void BuildPlan_RemoteUrl_UsesCloudModeAndPinnedHostedUrl()
+        {
+            RunInTempProject(projectRoot =>
+            {
+                var plan = ConfigureCommand.BuildPlan(
+                    new Dictionary<string, string> { ["agent"] = "claude-code", ["url"] = "https://ai-game.dev/mcp", ["project"] = projectRoot },
+                    FakeExe, FakeVersion);
+
+                Assert.Equal(ConnectionMode.Cloud, plan.Settings.ConnectionMode);
+                Assert.Contains("ai-game.dev/mcp/p/" + plan.ProjectPin, plan.ExpectedFileContent);
+            });
+        }
+
+        [Fact]
+        public void BuildPlan_StdioTransport_UsesStdioConfig()
+        {
+            RunInTempProject(projectRoot =>
+            {
+                var plan = ConfigureCommand.BuildPlan(
+                    new Dictionary<string, string> { ["agent"] = "claude-code", ["transport"] = "stdio", ["project"] = projectRoot },
+                    FakeExe, FakeVersion);
+
+                Assert.Equal(Consts.MCP.Server.TransportMethod.stdio, plan.Transport);
+            });
+        }
+
+        [Fact]
+        public void BuildPlan_UnknownAgent_Throws()
+        {
+            var ex = Assert.Throws<ConfigureCommand.ConfigureException>(() =>
+                ConfigureCommand.BuildPlan(
+                    new Dictionary<string, string> { ["agent"] = "definitely-not-an-agent" },
+                    FakeExe, FakeVersion));
+            Assert.Contains("Unknown --agent", ex.Message);
+        }
+
+        [Fact]
+        public void BuildPlan_MissingAgent_Throws()
+        {
+            Assert.Throws<ConfigureCommand.ConfigureException>(() =>
+                ConfigureCommand.BuildPlan(new Dictionary<string, string>(), FakeExe, FakeVersion));
+        }
+
+        // ── pure resolver units ──────────────────────────────────────────────────────────
+
+        [Theory]
+        [InlineData(null, Consts.MCP.Server.TransportMethod.streamableHttp)]
+        [InlineData("http", Consts.MCP.Server.TransportMethod.streamableHttp)]
+        [InlineData("streamableHttp", Consts.MCP.Server.TransportMethod.streamableHttp)]
+        [InlineData("stdio", Consts.MCP.Server.TransportMethod.stdio)]
+        public void ResolveTransport_Valid(string? raw, Consts.MCP.Server.TransportMethod expected)
+        {
+            Assert.Equal(expected, ConfigureCommand.ResolveTransport(raw));
+        }
+
+        [Fact]
+        public void ResolveTransport_Invalid_Throws()
+        {
+            Assert.Throws<ConfigureCommand.ConfigureException>(() => ConfigureCommand.ResolveTransport("carrier-pigeon"));
+        }
+
+        [Theory]
+        [InlineData("http://localhost", ConnectionMode.Local)]
+        [InlineData("http://127.0.0.1:8080", ConnectionMode.Local)]
+        [InlineData("https://ai-game.dev/mcp", ConnectionMode.Cloud)]
+        public void ResolveConnectionMode_Works(string host, ConnectionMode expected)
+        {
+            Assert.Equal(expected, ConfigureCommand.ResolveConnectionMode(host));
+        }
+
+        [Fact]
+        public void ResolveAuthOption_DefaultsByMode_ExplicitWins()
+        {
+            Assert.Equal(Consts.MCP.Server.AuthOption.oauth, ConfigureCommand.ResolveAuthOption(null, ConnectionMode.Cloud));
+            Assert.Equal(Consts.MCP.Server.AuthOption.none, ConfigureCommand.ResolveAuthOption(null, ConnectionMode.Local));
+            Assert.Equal(Consts.MCP.Server.AuthOption.none, ConfigureCommand.ResolveAuthOption("none", ConnectionMode.Cloud));
+        }
+
+        // ── helper: sandbox the process cwd + writes to a throwaway project dir ────────────
+
+        private static void RunInTempProject(Action<string> body)
+        {
+            var projectRoot = Path.GetFullPath(Path.Combine(Path.GetTempPath(), "gdmcp-configure-" + Guid.NewGuid().ToString("N")));
+            Directory.CreateDirectory(projectRoot);
+            try
+            {
+                body(projectRoot);
+            }
+            finally
+            {
+                try { Directory.Delete(projectRoot, recursive: true); } catch { /* best-effort cleanup */ }
+            }
+        }
+    }
+}

--- a/tests/GameDev.MCP.Server.Tests/HostAuthDefaultsTests.cs
+++ b/tests/GameDev.MCP.Server.Tests/HostAuthDefaultsTests.cs
@@ -1,0 +1,120 @@
+/*
+┌───────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                      │
+│  Repository: GitHub (https://github.com/IvanMurzak/GameDev-MCP-Server)    │
+│  Copyright (c) 2026 Ivan Murzak                                           │
+│  Licensed under the Apache License, Version 2.0.                          │
+│  See the LICENSE file in the project root for more information.           │
+└───────────────────────────────────────────────────────────────────────────┘
+*/
+
+using System;
+using com.IvanMurzak.GameDev.MCP.Server.Startup;
+using com.IvanMurzak.McpPlugin.Common;
+using Xunit;
+
+namespace com.IvanMurzak.GameDev.MCP.Server.Tests
+{
+    /// <summary>
+    /// Covers the transport-conditional auth default policy (mcp-authorize, design 02 §"modes"):
+    /// stdio → none, streamableHttp → oauth-when-configurable-else-none-with-warning, and explicit
+    /// choices are always left untouched.
+    /// </summary>
+    public class HostAuthDefaultsTests
+    {
+        [Fact]
+        public void Stdio_NoExplicitAuth_LeavesAsConfigured()
+        {
+            var decision = HostAuthDefaults.Decide(
+                Consts.MCP.Server.TransportMethod.stdio,
+                authExplicitlySet: false,
+                hasAuthIssuer: false,
+                hasPublicUrl: false);
+
+            Assert.Equal(HostAuthDefaults.Decision.LeaveAsConfigured, decision);
+        }
+
+        [Fact]
+        public void Http_NoExplicitAuth_IssuerAndPublicUrl_DefaultsToOauth()
+        {
+            var decision = HostAuthDefaults.Decide(
+                Consts.MCP.Server.TransportMethod.streamableHttp,
+                authExplicitlySet: false,
+                hasAuthIssuer: true,
+                hasPublicUrl: true);
+
+            Assert.Equal(HostAuthDefaults.Decision.DefaultHttpToOauth, decision);
+        }
+
+        [Theory]
+        [InlineData(true, false)]  // issuer only
+        [InlineData(false, true)]  // public-url only
+        [InlineData(false, false)] // neither
+        public void Http_NoExplicitAuth_MissingIssuerOrPublicUrl_FallsBackToNoneWithWarning(bool hasIssuer, bool hasPublicUrl)
+        {
+            var decision = HostAuthDefaults.Decide(
+                Consts.MCP.Server.TransportMethod.streamableHttp,
+                authExplicitlySet: false,
+                hasAuthIssuer: hasIssuer,
+                hasPublicUrl: hasPublicUrl);
+
+            Assert.Equal(HostAuthDefaults.Decision.DefaultHttpToNoneWithWarning, decision);
+        }
+
+        [Fact]
+        public void Http_ExplicitAuth_LeavesAsConfigured_EvenWithIssuer()
+        {
+            var decision = HostAuthDefaults.Decide(
+                Consts.MCP.Server.TransportMethod.streamableHttp,
+                authExplicitlySet: true,
+                hasAuthIssuer: true,
+                hasPublicUrl: true);
+
+            Assert.Equal(HostAuthDefaults.Decision.LeaveAsConfigured, decision);
+        }
+
+        [Fact]
+        public void IsAuthExplicitlySet_AuthArg_True()
+        {
+            Assert.True(HostAuthDefaults.IsAuthExplicitlySet(new[] { "--auth", "oauth" }));
+            Assert.True(HostAuthDefaults.IsAuthExplicitlySet(new[] { "--auth=none" }));
+            Assert.True(HostAuthDefaults.IsAuthExplicitlySet(new[] { "--authorization", "none" }));
+        }
+
+        [Fact]
+        public void IsAuthExplicitlySet_NoAuthSignal_False()
+        {
+            // Guard: no MCP_AUTH / MCP_AUTHORIZATION env leaking in from the test host.
+            var savedAuth = Environment.GetEnvironmentVariable(Consts.MCP.Server.Env.Auth);
+            var savedAuthorization = Environment.GetEnvironmentVariable(Consts.MCP.Server.Env.Authorization);
+            try
+            {
+                Environment.SetEnvironmentVariable(Consts.MCP.Server.Env.Auth, null);
+                Environment.SetEnvironmentVariable(Consts.MCP.Server.Env.Authorization, null);
+
+                Assert.False(HostAuthDefaults.IsAuthExplicitlySet(new[] { "--client-transport", "streamableHttp", "--port", "8080" }));
+                Assert.False(HostAuthDefaults.IsAuthExplicitlySet(Array.Empty<string>()));
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable(Consts.MCP.Server.Env.Auth, savedAuth);
+                Environment.SetEnvironmentVariable(Consts.MCP.Server.Env.Authorization, savedAuthorization);
+            }
+        }
+
+        [Fact]
+        public void IsAuthExplicitlySet_AuthEnv_True()
+        {
+            var saved = Environment.GetEnvironmentVariable(Consts.MCP.Server.Env.Auth);
+            try
+            {
+                Environment.SetEnvironmentVariable(Consts.MCP.Server.Env.Auth, "oauth");
+                Assert.True(HostAuthDefaults.IsAuthExplicitlySet(Array.Empty<string>()));
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable(Consts.MCP.Server.Env.Auth, saved);
+            }
+        }
+    }
+}

--- a/tests/GameDev.MCP.Server.Tests/OriginAllowListTests.cs
+++ b/tests/GameDev.MCP.Server.Tests/OriginAllowListTests.cs
@@ -1,0 +1,75 @@
+/*
+┌───────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                      │
+│  Repository: GitHub (https://github.com/IvanMurzak)                       │
+│  Copyright (c) 2026 Ivan Murzak                                           │
+│  Licensed under the Apache License, Version 2.0.                          │
+│  See the LICENSE file in the project root for more information.           │
+└───────────────────────────────────────────────────────────────────────────┘
+*/
+
+using System.Linq;
+using com.IvanMurzak.GameDev.MCP.Server.Startup;
+using com.IvanMurzak.McpPlugin.Common.Utils;
+using Xunit;
+
+namespace com.IvanMurzak.GameDev.MCP.Server.Tests
+{
+    /// <summary>
+    /// Covers the configurable Origin allow-list host surface (b2 carry-forward): parsing +
+    /// normalization + merge with the public-url origin, and that the replacement options are only
+    /// built when there is something to add.
+    /// </summary>
+    public class OriginAllowListTests
+    {
+        [Fact]
+        public void ParseOrigins_NullOrEmpty_ReturnsEmpty()
+        {
+            Assert.Empty(OriginAllowList.ParseOrigins(null));
+            Assert.Empty(OriginAllowList.ParseOrigins("   "));
+        }
+
+        [Fact]
+        public void ParseOrigins_SplitsCommaAndSemicolon_Normalizes_Dedups()
+        {
+            var origins = OriginAllowList.ParseOrigins("https://Console.Example.com/ , https://console.example.com ; https://b.example.com");
+
+            // Library normalization: scheme+host lowercased, path stripped, explicit port always appended
+            // ({scheme}://{host}:{port}). The two Console.Example variants dedup to one.
+            Assert.Equal(2, origins.Count);
+            Assert.Contains("https://console.example.com:443", origins);
+            Assert.Contains("https://b.example.com:443", origins);
+        }
+
+        [Fact]
+        public void BuildAllowedOrigins_MergesPublicUrlOriginAndExtras()
+        {
+            var merged = OriginAllowList.BuildAllowedOrigins(
+                publicUrl: "https://ai-game.dev/mcp",
+                rawAllowedOrigins: "https://console.example.com");
+
+            Assert.Contains("https://ai-game.dev:443", merged);
+            Assert.Contains("https://console.example.com:443", merged);
+        }
+
+        [Fact]
+        public void TryBuildOptions_NoExtraOrigins_ReturnsFalse()
+        {
+            var args = new DataArguments(new[] { "--public-url=https://ai-game.dev" });
+            Assert.False(OriginAllowList.TryBuildOptions(args, rawAllowedOrigins: null, out var options));
+            Assert.Null(options);
+        }
+
+        [Fact]
+        public void TryBuildOptions_WithExtraOrigins_BuildsOptions_KeepsLoopback()
+        {
+            var args = new DataArguments(new[] { "--public-url=https://ai-game.dev" });
+            Assert.True(OriginAllowList.TryBuildOptions(args, "https://console.example.com", out var options));
+
+            Assert.NotNull(options);
+            Assert.True(options!.AllowLoopback);
+            Assert.Contains("https://console.example.com:443", options.AllowedOrigins);
+            Assert.Contains("https://ai-game.dev:443", options.AllowedOrigins);
+        }
+    }
+}

--- a/tests/GameDev.MCP.Server.Tests/OriginAllowListTests.cs
+++ b/tests/GameDev.MCP.Server.Tests/OriginAllowListTests.cs
@@ -1,7 +1,7 @@
 /*
 ┌───────────────────────────────────────────────────────────────────────────┐
 │  Author: Ivan Murzak (https://github.com/IvanMurzak)                      │
-│  Repository: GitHub (https://github.com/IvanMurzak)                       │
+│  Repository: GitHub (https://github.com/IvanMurzak/GameDev-MCP-Server)    │
 │  Copyright (c) 2026 Ivan Murzak                                           │
 │  Licensed under the Apache License, Version 2.0.                          │
 │  See the LICENSE file in the project root for more information.           │

--- a/tests/GameDev.MCP.Server.Tests/SessionMigrationRestartResumeTests.cs
+++ b/tests/GameDev.MCP.Server.Tests/SessionMigrationRestartResumeTests.cs
@@ -1,0 +1,125 @@
+/*
+┌───────────────────────────────────────────────────────────────────────────┐
+│  Author: Ivan Murzak (https://github.com/IvanMurzak)                      │
+│  Repository: GitHub (https://github.com/IvanMurzak/GameDev-MCP-Server)    │
+│  Copyright (c) 2026 Ivan Murzak                                           │
+│  Licensed under the Apache License, Version 2.0.                          │
+│  See the LICENSE file in the project root for more information.           │
+└───────────────────────────────────────────────────────────────────────────┘
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using com.IvanMurzak.GameDev.MCP.Server;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Caching.Distributed;
+using Microsoft.Extensions.Logging.Abstractions;
+using ModelContextProtocol.Protocol;
+using Xunit;
+
+namespace com.IvanMurzak.GameDev.MCP.Server.Tests
+{
+    /// <summary>
+    /// Restart-resume gate for the Redis session-migration path (design 07 risk row "Session-migration
+    /// (Redis) interplay"; issue #70). Models a server-process restart: the durable distributed cache
+    /// (Redis in prod) survives, so a FRESH <see cref="SessionMigrationHandler"/> instance — a stand-in
+    /// for the restarted process, which has never seen the session in memory — must rehydrate the
+    /// session's <see cref="InitializeRequestParams"/> from the shared cache.
+    /// </summary>
+    public class SessionMigrationRestartResumeTests
+    {
+        [Fact]
+        public async Task PersistThenNewHandlerOnSameCache_RehydratesSession()
+        {
+            // One cache instance shared by both handlers == the Redis store surviving a restart.
+            var sharedCache = new SharedDistributedCache();
+            const string sessionId = "session-abc-123";
+            var original = NewInitializeParams();
+
+            // Process 1 persists on `initialize`.
+            var before = new SessionMigrationHandler(sharedCache, NullLogger<SessionMigrationHandler>.Instance);
+            await before.OnSessionInitializedAsync(new DefaultHttpContext(), sessionId, original, CancellationToken.None);
+
+            // Process 2 (restarted — brand-new handler, empty in-memory state) resumes from the cache.
+            var afterRestart = new SessionMigrationHandler(sharedCache, NullLogger<SessionMigrationHandler>.Instance);
+            var rehydrated = await afterRestart.AllowSessionMigrationAsync(new DefaultHttpContext(), sessionId, CancellationToken.None);
+
+            Assert.NotNull(rehydrated);
+            Assert.Equal(original.ProtocolVersion, rehydrated!.ProtocolVersion);
+            Assert.Equal(original.ClientInfo!.Name, rehydrated.ClientInfo!.Name);
+            Assert.Equal(original.ClientInfo.Version, rehydrated.ClientInfo.Version);
+        }
+
+        [Fact]
+        public async Task UnknownSessionAfterRestart_ReturnsNull()
+        {
+            var sharedCache = new SharedDistributedCache();
+            var afterRestart = new SessionMigrationHandler(sharedCache, NullLogger<SessionMigrationHandler>.Instance);
+
+            var result = await afterRestart.AllowSessionMigrationAsync(
+                new DefaultHttpContext(), sessionId: "never-persisted", CancellationToken.None);
+
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public async Task MalformedSessionId_RejectedDefensively()
+        {
+            // Defensive session-ID validation (issue #72): a value outside the accepted charset is never
+            // used as a cache key on either the persist or the migrate path.
+            var sharedCache = new SharedDistributedCache();
+            var handler = new SessionMigrationHandler(sharedCache, NullLogger<SessionMigrationHandler>.Instance);
+            const string badSessionId = "../../etc/passwd";
+
+            await handler.OnSessionInitializedAsync(new DefaultHttpContext(), badSessionId, NewInitializeParams(), CancellationToken.None);
+            Assert.Equal(0, sharedCache.Count); // nothing persisted for an invalid id
+
+            var result = await handler.AllowSessionMigrationAsync(new DefaultHttpContext(), badSessionId, CancellationToken.None);
+            Assert.Null(result);
+        }
+
+        private static InitializeRequestParams NewInitializeParams() => new()
+        {
+            ProtocolVersion = "2024-11-05",
+            Capabilities = new ClientCapabilities(),
+            ClientInfo = new Implementation { Name = "restart-resume-client", Version = "9.0.0" },
+        };
+
+        /// <summary>
+        /// Dictionary-backed <see cref="IDistributedCache"/> whose contents persist across handler
+        /// instances — the test stand-in for a Redis store that outlives a server-process restart.
+        /// </summary>
+        private sealed class SharedDistributedCache : IDistributedCache
+        {
+            private readonly Dictionary<string, byte[]> _store = new();
+
+            public int Count => _store.Count;
+
+            public byte[]? Get(string key) => _store.TryGetValue(key, out var v) ? v : null;
+
+            public Task<byte[]?> GetAsync(string key, CancellationToken token = default) => Task.FromResult(Get(key));
+
+            public void Set(string key, byte[] value, DistributedCacheEntryOptions options) => _store[key] = value;
+
+            public Task SetAsync(string key, byte[] value, DistributedCacheEntryOptions options, CancellationToken token = default)
+            {
+                Set(key, value, options);
+                return Task.CompletedTask;
+            }
+
+            public void Refresh(string key) { }
+
+            public Task RefreshAsync(string key, CancellationToken token = default) => Task.CompletedTask;
+
+            public void Remove(string key) => _store.Remove(key);
+
+            public Task RemoveAsync(string key, CancellationToken token = default)
+            {
+                _store.Remove(key);
+                return Task.CompletedTask;
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Advances the thin host to **McpPlugin.Server 7.0.0-preview.1** (the mcp-authorize OAuth resource-server major) — **CODE half of `c1`** (design `mcp-authorize` 02/06/07). Code + tests + docs only.
- New host arg/env surface (`--auth`/`--auth-issuer`/`--public-url`/`--bind`/`MCP_ALLOWED_ORIGINS`), a transport-conditional auth default (stdio → `none`, http → `oauth`), and a `configure --agent <id>` subcommand that writes pinned, URL-only client configs from the terminal.
- **No `<Version>` / `server.json` version bump; no release/publish** — deferred to the separate, owner-gated `c1-release` step against McpPlugin 7.0 stable.

### What changed

- **deps** — `McpPlugin.Server` `6.11.1` → `7.0.0-preview.1` (ReflectorNet stays `5.3.2`, exactly what 7.0 requires per its dependency graph); add `com.IvanMurzak.McpPlugin` for the shared configurator registry + `ProjectIdentity`/`ProjectMarker`; README + `docs/NUGET.md` compatibility tables refreshed.
- **auth** — `HostAuthDefaults` applies the transport-conditional default: http defaults to `oauth` **only when `--auth-issuer` + `--public-url` are set** (the library's `AccountMcpStrategy.Validate` throws otherwise), else stays `none` with a loud warning so the zero-config `docker run` / `--port 8080` quickstart still works. An explicit `--auth` always wins.
- **bind** — `--bind`/`MCP_BIND` forwarded to the library's bind-aware `UseKestrelForMcpPlugin(port, bind)` overload (default loopback per D8; `any`/`0.0.0.0` for hosted deploys a reverse proxy must reach).
- **origins** — `MCP_ALLOWED_ORIGINS`/`--allowed-origins` registers an extended `OriginValidationOptions` (loopback + `--public-url` origin + configured origins) so hosted browser clients work without a blanket `*` on credentialed paths (b2 carry-forward).
- **configure** — `gamedev-mcp-server configure --agent <id> [--url ...] [--transport stdio|http] [--project <path>]` consumes the shared `AiAgentConfiguratorRegistry`; every written config is project-scoped, URL-only, and pinned (`…/p/<pin>` + deterministic per-project port).
- **docs** — README (Configuration table + Authentication + Configure sections) and `server.json` env surface rewritten.

## Test plan

- [x] `dotnet build -c Release` — 0 warnings / 0 errors against the 7.0.0-preview.1 pins.
- [x] `docker build` — image builds (CI-parity Dockerfile leg).
- [x] `dotnet test` — 49/49 green: `HostAuthDefaults` decision matrix, `configure` (Claude Code `.mcp.json` + Codex `.codex/config.toml` pinned writes), Origin allow-list, and a **Redis session-migration restart-resume** test (persist → fresh handler on the same cache → rehydrate).
- [x] Real smoke: `configure --agent claude-code` wrote `http://localhost:20459/p/6bdf6fc6`; `configure --agent codex --url https://ai-game.dev/mcp` wrote `https://ai-game.dev/mcp/p/6bdf6fc6`.

## Deferred (out of scope — separate owner-gated release step)

- The `9.0.0` `<Version>` / `server.json` bump + Docker/7-zip/dotnet-tool publish against McpPlugin 7.0 **stable**; software submodule pointer bump.
- Live end-to-end container smoke with a real Claude Code MCP client + the scripted a6 OAuth agent against a deployed cloud AS (needs the Phase-1 AS deployed + an interactive MCP client; the local gate covers build + docker + unit/integration tests).

Closes #12
