### PR TITLE
chore(release): 9.0.0 — McpPlugin.Server 7.0 auth surface

### DIFF
--- a/com.IvanMurzak.GameDev.MCP.Server.csproj
+++ b/com.IvanMurzak.GameDev.MCP.Server.csproj
@@ -13,7 +13,7 @@
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>gamedev-mcp-server</ToolCommandName>
     <PackageId>com.IvanMurzak.GameDev.MCP.Server</PackageId>
-    <Version>8.0.3</Version>
+    <Version>9.0.0</Version>
     <Authors>Ivan Murzak</Authors>
     <Company>Ivan Murzak</Company>
     <Copyright>Copyright © 2026 Ivan Murzak</Copyright>

--- a/server.json
+++ b/server.json
@@ -7,13 +7,13 @@
     "url": "https://github.com/IvanMurzak/GameDev-MCP-Server",
     "source": "github"
   },
-  "version": "8.0.3",
+  "version": "9.0.0",
   "packages": [
     {
       "registry_type": "oci",
       "registry_base_url": "https://docker.io",
       "identifier": "aigamedeveloper/mcp-server",
-      "version": "8.0.3",
+      "version": "9.0.0",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
Major release **8.0.3 → 9.0.0** for the mcp-authorize work.

## What
- Consumes **McpPlugin.Server 7.0** (OAuth resource-server surface): `--auth` / `--bind` / `MCP_ALLOWED_ORIGINS` + `configure --agent` subcommand (Claude Code + Codex). Merged in #13 (`629d84a`).
- Version bump only in this PR: `<Version>` (csproj) + `server.json` (top-level + `packages[0]`) → 9.0.0.

## Why major
Per the mcp-authorize design the server moves to the 9.0 line for the auth model (behavioral: auth resource-server + loopback bind default). Consumers **pin** `ServerVersion` and download the binary, so 9.0.0 reaches a plugin only when its pin is bumped (the deliberate cascade).

## Release trigger
This repo has no `release.yml`; publishing the GitHub Release `v9.0.0` (after merge) fires NuGet + Docker `aigamedeveloper/mcp-server:9.0.0`/`:latest` + the 7 signed RID zips + SHA256SUMS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)