### PR TITLE
chore(deps): bump McpPlugin pins to 7.0.1 (g4 pinned-route fix)

### DIFF
--- a/com.IvanMurzak.GameDev.MCP.Server.csproj
+++ b/com.IvanMurzak.GameDev.MCP.Server.csproj
@@ -57,14 +57,14 @@
   -->
   <ItemGroup Condition="'$(UseLocalMcpPlugin)' != 'true'">
     <PackageReference Include="com.IvanMurzak.ReflectorNet" Version="5.3.2" />
-    <PackageReference Include="com.IvanMurzak.McpPlugin.Server" Version="7.0.0-preview.1" />
+    <PackageReference Include="com.IvanMurzak.McpPlugin.Server" Version="7.0.1" />
     <!--
       Base McpPlugin package: the McpPlugin.Server package does NOT depend on it, but it hosts the
       shared AI-agent configurator registry (AiAgentConfiguratorRegistry) + ProjectIdentity /
       ProjectMarker primitives the `configure` subcommand consumes from the terminal. Pinned in
       lockstep with McpPlugin.Server.
     -->
-    <PackageReference Include="com.IvanMurzak.McpPlugin" Version="7.0.0-preview.1" />
+    <PackageReference Include="com.IvanMurzak.McpPlugin" Version="7.0.1" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(UseLocalMcpPlugin)' == 'true'">


### PR DESCRIPTION
Adopts **MCP-Plugin-dotnet 7.0.1** (both `com.IvanMurzak.McpPlugin.Server` and `com.IvanMurzak.McpPlugin` pins, `7.0.0-preview.1` → `7.0.1`).

7.0.1 contains the **g4 fix** ([MCP-Plugin-dotnet #156](https://github.com/IvanMurzak/MCP-Plugin-dotnet/pull/156)) that serves the MCP endpoint at the design-mandated project-pinned path `/p/<pin>`. The hosted `https://ai-game.dev/mcp/p/<pin>` currently 404s because the deployed 9.0.0 image was built against `7.0.0-preview.1` (pre-g4). This rebuilds the server against the fixed package for the 9.0.1 release + prod deploy.

2-line pin bump; ReflectorNet pin + ProjectReferences untouched.