### PR TITLE
chore: release GameDev-MCP-Server 9.0.1

### DIFF
--- a/com.IvanMurzak.GameDev.MCP.Server.csproj
+++ b/com.IvanMurzak.GameDev.MCP.Server.csproj
@@ -13,7 +13,7 @@
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>gamedev-mcp-server</ToolCommandName>
     <PackageId>com.IvanMurzak.GameDev.MCP.Server</PackageId>
-    <Version>9.0.0</Version>
+    <Version>9.0.1</Version>
     <Authors>Ivan Murzak</Authors>
     <Company>Ivan Murzak</Company>
     <Copyright>Copyright © 2026 Ivan Murzak</Copyright>

--- a/server.json
+++ b/server.json
@@ -7,13 +7,13 @@
     "url": "https://github.com/IvanMurzak/GameDev-MCP-Server",
     "source": "github"
   },
-  "version": "9.0.0",
+  "version": "9.0.1",
   "packages": [
     {
       "registry_type": "oci",
       "registry_base_url": "https://docker.io",
       "identifier": "aigamedeveloper/mcp-server",
-      "version": "9.0.0",
+      "version": "9.0.1",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
Automated release bump `9.0.0` -> `9.0.1` (explicit). Merging to the default branch lands the version; the GitHub Release publish (step 02) then fires the deploy workflows.