### PR TITLE
chore(deps): bump McpPlugin pins to 7.1.0 (g6)

### DIFF
--- a/com.IvanMurzak.GameDev.MCP.Server.csproj
+++ b/com.IvanMurzak.GameDev.MCP.Server.csproj
@@ -57,14 +57,14 @@
   -->
   <ItemGroup Condition="'$(UseLocalMcpPlugin)' != 'true'">
     <PackageReference Include="com.IvanMurzak.ReflectorNet" Version="5.3.2" />
-    <PackageReference Include="com.IvanMurzak.McpPlugin.Server" Version="7.0.1" />
+    <PackageReference Include="com.IvanMurzak.McpPlugin.Server" Version="7.1.0" />
     <!--
       Base McpPlugin package: the McpPlugin.Server package does NOT depend on it, but it hosts the
       shared AI-agent configurator registry (AiAgentConfiguratorRegistry) + ProjectIdentity /
       ProjectMarker primitives the `configure` subcommand consumes from the terminal. Pinned in
       lockstep with McpPlugin.Server.
     -->
-    <PackageReference Include="com.IvanMurzak.McpPlugin" Version="7.0.1" />
+    <PackageReference Include="com.IvanMurzak.McpPlugin" Version="7.1.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(UseLocalMcpPlugin)' == 'true'">


### PR DESCRIPTION
Adopts McpPlugin 7.1.0 (AuthOption.token + LocalTokenMcpStrategy + shared ServerLaunchArguments, g6). Rebuilds the server for the 9.1.0 release (offline local token auth + oauth-local).