### PR TITLE
chore: bump McpPlugin to 7.1.1

### DIFF
--- a/com.IvanMurzak.GameDev.MCP.Server.csproj
+++ b/com.IvanMurzak.GameDev.MCP.Server.csproj
@@ -57,7 +57,7 @@
   -->
   <ItemGroup Condition="'$(UseLocalMcpPlugin)' != 'true'">
     <PackageReference Include="com.IvanMurzak.ReflectorNet" Version="5.3.2" />
-    <PackageReference Include="com.IvanMurzak.McpPlugin.Server" Version="7.1.0" />
+    <PackageReference Include="com.IvanMurzak.McpPlugin.Server" Version="7.1.1" />
     <!--
       Base McpPlugin package: the McpPlugin.Server package does NOT depend on it, but it hosts the
       shared AI-agent configurator registry (AiAgentConfiguratorRegistry) + ProjectIdentity /


### PR DESCRIPTION
Automated downstream bump of `com.IvanMurzak.McpPlugin` `7.1.0` -> `7.1.1` (MCP-Plugin-dotnet release b80834aa31a4).