### PR TITLE
chore: bump base McpPlugin pin to 7.2.0 (restore lockstep with .Server)

### DIFF
--- a/com.IvanMurzak.GameDev.MCP.Server.csproj
+++ b/com.IvanMurzak.GameDev.MCP.Server.csproj
@@ -64,7 +64,7 @@
       ProjectMarker primitives the `configure` subcommand consumes from the terminal. Pinned in
       lockstep with McpPlugin.Server.
     -->
-    <PackageReference Include="com.IvanMurzak.McpPlugin" Version="7.1.0" />
+    <PackageReference Include="com.IvanMurzak.McpPlugin" Version="7.2.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(UseLocalMcpPlugin)' == 'true'">


### PR DESCRIPTION
The MCP-Plugin-dotnet **7.2.0** cascade bumps `com.IvanMurzak.McpPlugin.Server` only (by design), leaving the base `com.IvanMurzak.McpPlugin` at **7.1.0** — directly beneath a comment asserting the two are *"Pinned in lockstep"*.

**This is functional, not cosmetic.** The base package carries the `AgentConfig` registry and the `ProjectIdentity` / `ProjectMarker` primitives that the `configure` subcommand consumes. Releasing with a 7.1.0 base would ship a server whose configure-path primitives lag the **pin v2 (separator normalization) + dual-hash** work delivered in 7.2.0 — the exact behaviour the auth-fixes release exists to deliver.

Lands ahead of the GameDev-MCP-Server 9.2.0 release so that release builds from correct pins.

Verified locally: `dotnet build` succeeds with both pins at 7.2.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JmhxryEuZcqu2KDsVbyvt6