### PR TITLE
chore: bump base McpPlugin pin to 7.3.0 (restore lockstep with .Server)

### DIFF
--- a/com.IvanMurzak.GameDev.MCP.Server.csproj
+++ b/com.IvanMurzak.GameDev.MCP.Server.csproj
@@ -64,7 +64,7 @@
       ProjectMarker primitives the `configure` subcommand consumes from the terminal. Pinned in
       lockstep with McpPlugin.Server.
     -->
-    <PackageReference Include="com.IvanMurzak.McpPlugin" Version="7.2.0" />
+    <PackageReference Include="com.IvanMurzak.McpPlugin" Version="7.3.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(UseLocalMcpPlugin)' == 'true'">


### PR DESCRIPTION
The MCP-Plugin-dotnet cascade bumps `com.IvanMurzak.McpPlugin.Server` **only**, by design, so the base `com.IvanMurzak.McpPlugin` pin lags every release. **This is the second consecutive cascade where it drifted** (7.1.0 vs 7.2.0 last time, 7.2.0 vs 7.3.0 now) — directly beneath a comment asserting the two are *"Pinned in lockstep"*.

**It matters more than usual for 7.3.0.** The base package carries the `AgentConfig` registry and the `ProjectIdentity` / `ProjectMarker` primitives that the `configure` subcommand consumes — and 7.3.0 *is* the port-derivation fix (pin and port from one v2 normalization; a user-typed port honoured on both transports). Releasing the server on a 7.2.0 base would ship `configure` still writing configs with the **old** port logic — the exact bug this release exists to fix.

Verified locally: `dotnet build` succeeds with both pins at 7.3.0.

Worth a follow-up: nothing enforces this lockstep, and it has now silently drifted twice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JmhxryEuZcqu2KDsVbyvt6