### PR TITLE
chore(ci): upgrade Node20-deprecated actions to Node24-capable versions

### DIFF
--- a/.github/workflows/deploy_nuget.yml
+++ b/.github/workflows/deploy_nuget.yml
@@ -45,7 +45,7 @@ jobs:
           echo "Extracted version: $version (from $raw)"
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: "9.0.x"
 

--- a/.github/workflows/deploy_server_executables.yml
+++ b/.github/workflows/deploy_server_executables.yml
@@ -194,7 +194,7 @@ jobs:
           rm -f "$KEY_PATH"
 
       - name: Upload release assets (osx + linux)
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           files: ./publish/*.zip
           tag_name: ${{ github.event.release.tag_name }}
@@ -268,7 +268,7 @@ jobs:
           Get-ChildItem -Path $publishRoot -Filter "*.zip" | Select-Object Name, Length
 
       - name: Upload release assets (win)
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           files: ./publish/*.zip
           tag_name: ${{ github.event.release.tag_name }}
@@ -374,7 +374,7 @@ jobs:
           sha256sum -c SHA256SUMS
 
       - name: Upload SHA256SUMS to release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           files: checksums/SHA256SUMS
           tag_name: ${{ steps.tag.outputs.tag }}

--- a/.github/workflows/dockerhub_description.yml
+++ b/.github/workflows/dockerhub_description.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Sync README to Docker Hub overview
         continue-on-error: true # best-effort publish; never fail CI on a credential issue
-        uses: peter-evans/dockerhub-description@v4
+        uses: peter-evans/dockerhub-description@v5
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/test_pull_request.yml
+++ b/.github/workflows/test_pull_request.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: "9.0.x"
 


### PR DESCRIPTION
GitHub is force-running these actions on Node 24 already; the pinned
majors are the last Node20-based releases. Runtime-compatibility fix.

- actions/setup-dotnet            @v4 -> @v5  (2 occurrences)
    .github/workflows/test_pull_request.yml
    .github/workflows/deploy_nuget.yml
- peter-evans/dockerhub-description @v4 -> @v5  (1 occurrence)
    .github/workflows/dockerhub_description.yml
- softprops/action-gh-release     @v2 -> @v3  (3 occurrences)
    .github/workflows/deploy_server_executables.yml
      (osx+linux assets, win assets, SHA256SUMS backfill)

Version pins only. No changes to Authenticode signing, Docker
build/push, or release-asset logic. setup-dotnet v5 and
action-gh-release v3 are pure Node24 runtime bumps with no documented
input/output changes; all existing `with:` inputs (dotnet-version,
files, tag_name, make_latest) are unchanged in the new majors.

Deliberately untouched (not Node20-deprecated / out of scope):
actions/checkout@v6 (already at target), NuGet/login@v1 and
azure/trusted-signing-action@v0, docker/setup-buildx-action@v4,
docker/login-action@v4, docker/build-push-action@v7.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_012WxMrEo6Nk4RCQZjA4LkFC
