### PR TITLE
chore: restore McpPlugin lockstep with McpPlugin.Server at 7.5.0

### DIFF
--- a/com.IvanMurzak.GameDev.MCP.Server.csproj
+++ b/com.IvanMurzak.GameDev.MCP.Server.csproj
@@ -64,7 +64,7 @@
       ProjectMarker primitives the `configure` subcommand consumes from the terminal. Pinned in
       lockstep with McpPlugin.Server.
     -->
-    <PackageReference Include="com.IvanMurzak.McpPlugin" Version="7.3.0" />
+    <PackageReference Include="com.IvanMurzak.McpPlugin" Version="7.5.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(UseLocalMcpPlugin)' == 'true'">


### PR DESCRIPTION
The MCP-Plugin-dotnet 7.5.0 release cascade bumps only the `McpPlugin.Server`
`<PackageReference>` for this consumer, leaving the base `com.IvanMurzak.McpPlugin`
at 7.3.0 — against this csproj's own comment declaring the two "Pinned in lockstep
with McpPlugin.Server".

This restores both to 7.5.0 before the server release is cut, so the image
production runs carries one consistent set of McpPlugin assemblies instead of a
2-minor split.

Context: `.Server` 7.5.0 carries the pinned system-tools REST route
(MCP-Plugin-dotnet #185) and the fail-closed project-pin validation (#187).