### PR TITLE
chore: bump ReflectorNet to 5.4.0

### DIFF
--- a/com.IvanMurzak.GameDev.MCP.Server.csproj
+++ b/com.IvanMurzak.GameDev.MCP.Server.csproj
@@ -56,7 +56,7 @@
     with the engine plugins (Unity-MCP / Godot-MCP / Unreal-MCP).
   -->
   <ItemGroup Condition="'$(UseLocalMcpPlugin)' != 'true'">
-    <PackageReference Include="com.IvanMurzak.ReflectorNet" Version="5.3.3" />
+    <PackageReference Include="com.IvanMurzak.ReflectorNet" Version="5.4.0" />
     <PackageReference Include="com.IvanMurzak.McpPlugin.Server" Version="7.5.1" />
     <!--
       Base McpPlugin package: the McpPlugin.Server package does NOT depend on it, but it hosts the


### PR DESCRIPTION
Automated downstream bump of `com.IvanMurzak.ReflectorNet` `5.3.3` -> `5.4.0` (ReflectorNet release 1dff550140a4).