### PR TITLE
chore: release GameDev-MCP-Server 9.2.4

### DIFF
--- a/com.IvanMurzak.GameDev.MCP.Server.csproj
+++ b/com.IvanMurzak.GameDev.MCP.Server.csproj
@@ -13,7 +13,7 @@
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>gamedev-mcp-server</ToolCommandName>
     <PackageId>com.IvanMurzak.GameDev.MCP.Server</PackageId>
-    <Version>9.2.3</Version>
+    <Version>9.2.4</Version>
     <Authors>Ivan Murzak</Authors>
     <Company>Ivan Murzak</Company>
     <Copyright>Copyright © 2026 Ivan Murzak</Copyright>

--- a/server.json
+++ b/server.json
@@ -7,13 +7,13 @@
     "url": "https://github.com/IvanMurzak/GameDev-MCP-Server",
     "source": "github"
   },
-  "version": "9.2.3",
+  "version": "9.2.4",
   "packages": [
     {
       "registry_type": "oci",
       "registry_base_url": "https://docker.io",
       "identifier": "aigamedeveloper/mcp-server",
-      "version": "9.2.3",
+      "version": "9.2.4",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
Automated release bump `9.2.3` -> `9.2.4` (patch). Merging to the default branch lands the version; the GitHub Release publish (step 02) then fires the deploy workflows.