### PR TITLE
fix(logging): default to Info and make the level env-overridable, not hardcoded Trace

### DIFF
--- a/NLog.config
+++ b/NLog.config
@@ -42,7 +42,25 @@
 
   <rules>
     <logger name="Microsoft.*"  maxlevel="Warn"   final="true" />
-    <logger name="*"            minlevel="Trace"  maxlevel="Warn" writeTo="logFile,console" />
+    <!-- Verbosity floor, overridable per deployment via the MCP_LOG_LEVEL
+         environment variable (Trace|Debug|Info|Warn|Error|Fatal).
+
+         This shipped as a hardcoded minlevel="Trace" through 9.2.4, which logs
+         every MCP message body. Because this server RELAYS traffic, those bodies
+         include engine-console text copied verbatim out of users' editors — so
+         at Trace the log is not only enormous but full of other people's data.
+         Measured on the hosted deployment: 39-54k lines/min, 5-12 GB/day.
+
+         Trace also made the logs it produced useless for the thing logs are for.
+         The file target below archives at 10 MB x 5, so at that rate
+         server-log.txt held about TEN MINUTES of history; at Info the same 50 MB
+         holds days. A production incident was diagnosed against this server on
+         2026-07-30 and its raw log lines were already gone by the time anyone
+         looked. Lower verbosity here means MORE retained history, not less.
+
+         Set MCP_LOG_LEVEL=Trace to restore the full protocol dump while
+         debugging. Empty/unset => Info. -->
+    <logger name="*"            minlevel="${environment:MCP_LOG_LEVEL:whenEmpty=Info}" maxlevel="Warn" writeTo="logFile,console" />
     <logger name="*"            minlevel="Error"  writeTo="logFile,console,errorLogFile" />
   </rules>
 

--- a/README.md
+++ b/README.md
@@ -114,8 +114,15 @@ CLI arguments override environment variables.
 | `MCP_PUBLIC_URL` | `--public-url` | — | This server's canonical public URL / token audience (e.g. `https://ai-game.dev/mcp`). Required for `oauth`; seeds the Origin allow-list |
 | `MCP_BIND` | `--bind` | `loopback` | Bind address: `loopback`, `any` (0.0.0.0), or a specific IP. Hosted deploys behind a proxy set `any`/`0.0.0.0` |
 | `MCP_ALLOWED_ORIGINS` | `--allowed-origins` | — | Comma/semicolon-separated additional allowed browser Origins (added to loopback + the `--public-url` origin) |
+| `MCP_LOG_LEVEL` | — | `Info` | Log verbosity floor: `Trace`, `Debug`, `Info`, `Warn`, `Error`, `Fatal`. Read by NLog, so unlike the rest of this table it has no CLI equivalent |
 
 Logs are written to `logs/server-log.txt` (and `logs/server-log-error.txt`); in stdio mode console logging is redirected to stderr so stdout stays clean for the MCP JSON stream.
+
+The default level is `Info`. Set `MCP_LOG_LEVEL=Trace` to dump every MCP message
+body while debugging a protocol issue — but expect volume: on a busy hosted
+deployment Trace measured 39-54k lines/min (5-12 GB/day), which rotates
+`server-log.txt` (10 MB x 5 archives) down to roughly ten minutes of retained
+history. Lower verbosity keeps *more* usable history, not less.
 
 ## Authentication
 

--- a/docs/NUGET.md
+++ b/docs/NUGET.md
@@ -71,8 +71,11 @@ CLI arguments override environment variables.
 | `MCP_PUBLIC_URL` | `--public-url` | — | Canonical public URL / token audience. Required for `oauth` |
 | `MCP_BIND` | `--bind` | `loopback` | Bind address: `loopback`, `any` (0.0.0.0), or a specific IP |
 | `MCP_ALLOWED_ORIGINS` | `--allowed-origins` | — | Additional allowed browser Origins (comma/semicolon-separated) |
+| `MCP_LOG_LEVEL` | — | `Info` | Log verbosity floor: `Trace`, `Debug`, `Info`, `Warn`, `Error`, `Fatal`. Read by NLog, so it has no CLI equivalent |
 
 In stdio mode console logging is redirected to stderr so stdout stays clean for the MCP JSON stream.
+
+The default level is `Info`. `MCP_LOG_LEVEL=Trace` dumps every MCP message body for debugging; it is very high volume and rotates `server-log.txt` down to a few minutes of retained history, so set it only while reproducing an issue.
 
 Write a pinned, URL-only MCP client config for an AI agent from the terminal:
 `gamedev-mcp-server configure --agent claude-code` (or `--agent codex --url https://ai-game.dev/mcp`; `configure --help` lists all agents).


### PR DESCRIPTION
## The problem

`NLog.config` has shipped `minlevel="Trace"` for as long as this repo has existed. Every published image, dotnet tool and standalone zip therefore logs the full body of every MCP message by default.

For this server specifically that is worse than ordinary log noise, for two reasons.

**It logs other people's data.** This server *relays* traffic. Message bodies carry engine-console text copied verbatim out of users' editors — their exception names, asset paths, script errors — and at the default setting all of it lands in the operator's log.

**It destroys the history it produces.** The file target archives at 10 MB × 5. At the rate measured on the hosted deployment (39–54k lines/min, 5–12 GB/day) `server-log.txt` held roughly **ten minutes** before rolling. A production incident was diagnosed against this server on 2026-07-30 and its raw log lines were already gone by the time anyone looked — it had to be reconstructed from a watchdog's own log and a database table. At `Info` the same 50 MB holds days, so **this change increases the amount of usable history**.

## The change

```xml
<logger name="*" minlevel="${environment:MCP_LOG_LEVEL:whenEmpty=Info}" maxlevel="Warn" writeTo="logFile,console" />
```

`MCP_LOG_LEVEL=Trace` restores the full protocol dump for debugging. Added to the env-var tables in `README.md` and `docs/NUGET.md` — with a `—` in the CLI-argument column, since NLog reads it directly and it has no CLI equivalent.

## Verification

Ran against the published `aigamedeveloper/mcp-server:9.2.4` image with this exact file mounted at `/app/NLog.config` — the path it ships to — in a throwaway container. Three assertions, because "the log got quieter" is also what a broken logger looks like:

| condition | `trce`+`dbug` lines | expected |
|---|---|---|
| `MCP_LOG_LEVEL` unset | **0** | suppressed |
| `MCP_LOG_LEVEL=Trace` | **2** | restored |
| unset, counting `info`+`warn` | **6** | still logging — the floor moved, logging did not stop |

I checked the env-var route before relying on it: `Logging__LogLevel__Default` has **no effect** on this server, because it logs through NLog rather than the Microsoft console provider, so the standard .NET override is silently ignored. NLog rules are the only lever, which is why this has to be fixed here rather than in the consumer's compose file.

## Behaviour change

Default console/file verbosity drops **Trace → Info** for every consumer — the Unity, Godot and Unreal plugins all embed this server. Anyone relying on the old default sets `MCP_LOG_LEVEL=Trace`.

I think that is the right default: `Trace` in a released artifact reads as an oversight rather than a choice, and as measured above it makes the logs less useful, not more. Flagging it explicitly because it is not a silent-safe change.

## Why it matters beyond this repo

The hosted deployment currently pins `Info` by bind-mounting its own copy of this file over `/app/NLog.config`. That mount exists *only* because this default could not be overridden, and it carries a real cost: the copy is frozen at 9.2.4, so any future change made here would be silently overridden by a stale file the consumer does not own. Once a release carries this change, that mount can be deleted and the drift risk goes with it.

Needs a release to reach the image; happy to follow with the version-bump chore PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)