### PR TITLE
fix(session): seed an 8h idle window so a local session outlives a working day

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ CLI arguments override environment variables.
 | `MCP_PLUGIN_PORT` | `--port` | `8080` | Client → Server ← Plugin connection port |
 | `MCP_PLUGIN_CLIENT_TIMEOUT` | `--plugin-timeout` | `10000` | Plugin → Server connection timeout (ms) |
 | `MCP_PLUGIN_CLIENT_TRANSPORT` | `--client-transport` | `stdio` | Client → Server transport: `stdio` or `streamableHttp` |
-| `MCP_PLUGIN_IDLE_TIMEOUT_SECONDS` | `--idle-timeout-seconds` | `21600` | streamableHttp idle-session eviction window (this host seeds 6h instead of the package default of 600s) |
+| `MCP_PLUGIN_IDLE_TIMEOUT_SECONDS` | `--idle-timeout-seconds` | `28800` | streamableHttp idle-session eviction window (this host seeds 8h instead of the package default of 600s, so a local session survives a working day). Multi-tenant hosts should lower it and use a Redis session-migration record for long-window resumption |
 | `MCP_AUTH` | `--auth` | transport-dependent (see [Authentication](#authentication)) | Authentication mode: `none` or `oauth` |
 | `MCP_AUTH_ISSUER` | `--auth-issuer` | — | OAuth authorization-server URL (e.g. `https://ai-game.dev`). Required for `oauth` |
 | `MCP_PUBLIC_URL` | `--public-url` | — | This server's canonical public URL / token audience (e.g. `https://ai-game.dev/mcp`). Required for `oauth`; seeds the Origin allow-list |

--- a/docs/NUGET.md
+++ b/docs/NUGET.md
@@ -65,7 +65,7 @@ CLI arguments override environment variables.
 | `MCP_PLUGIN_PORT` | `--port` | `8080` | Client to Server to Plugin connection port |
 | `MCP_PLUGIN_CLIENT_TIMEOUT` | `--plugin-timeout` | `10000` | Plugin to Server connection timeout (ms) |
 | `MCP_PLUGIN_CLIENT_TRANSPORT` | `--client-transport` | `stdio` | Client to Server transport: `stdio` or `streamableHttp` |
-| `MCP_PLUGIN_IDLE_TIMEOUT_SECONDS` | `--idle-timeout-seconds` | `21600` | streamableHttp idle-session eviction window |
+| `MCP_PLUGIN_IDLE_TIMEOUT_SECONDS` | `--idle-timeout-seconds` | `28800` | streamableHttp idle-session eviction window (8h, so a local session survives a working day) |
 | `MCP_AUTH` | `--auth` | transport-dependent | Authentication mode: `none` or `oauth` (stdio -> none; http -> oauth when issuer + public-url set) |
 | `MCP_AUTH_ISSUER` | `--auth-issuer` | — | OAuth authorization-server URL. Required for `oauth` |
 | `MCP_PUBLIC_URL` | `--public-url` | — | Canonical public URL / token audience. Required for `oauth` |

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -42,13 +42,22 @@ namespace com.IvanMurzak.GameDev.MCP.Server
             // Configure NLog
             LogManager.Setup().LoadConfigurationFromFile("NLog.config");
 
-            // Default the streamableHttp idle-session window to 6 hours for this local server.
+            // Default the streamableHttp idle-session window to 8 hours for this local server.
             // The plugin's built-in default is 600s (10 min), which is too aggressive for a
             // single-user local editor session and drops the MCP session mid-work. We only seed
             // the env var when it is unset, and DataArguments parses CLI args after env vars, so an
             // explicit MCP_PLUGIN_IDLE_TIMEOUT_SECONDS or --idle-timeout-seconds still overrides this.
+            //
+            // 6h -> 8h: the dominant deployment for this host is a developer running it on their own
+            // machine beside an editor, where the session should outlive a working day rather than a
+            // sitting. 6h expired over a long day; 8h covers one. The cost is bounded and local — an
+            // idle session pins its SseEventWriter buffer until evicted, and a single-user machine
+            // has a handful of sessions, not thousands. Multi-tenant HOSTED deployments must not
+            // inherit this: ai-game.dev sets MCP_PLUGIN_IDLE_TIMEOUT_SECONDS=600 explicitly and
+            // relies on the Redis session-migration record for long-window resumption instead, which
+            // costs ~0.5 KB per session rather than tens of MiB.
             if (string.IsNullOrEmpty(Environment.GetEnvironmentVariable(Consts.MCP.Server.Env.IdleTimeoutSeconds)))
-                Environment.SetEnvironmentVariable(Consts.MCP.Server.Env.IdleTimeoutSeconds, "21600"); // 6 hours
+                Environment.SetEnvironmentVariable(Consts.MCP.Server.Env.IdleTimeoutSeconds, "28800"); // 8 hours
 
             // Transport-conditional authentication default (mcp-authorize, design 02 §"modes"):
             // stdio => none, streamableHttp => oauth. DataArguments defaults auth to `none` for BOTH


### PR DESCRIPTION
## Why

The dominant deployment for this host is a developer installing the server **on their own machine** next to an editor. There the MCP session should survive a working *day*, not a sitting — and users are reporting sessions dropping out from under them.

This host already seeded **6h** over the McpPlugin package default of 600s (that seed has been here since v8.0.0, so it is not a case of users running something older). Raising it to **8h** covers a long working day rather than expiring partway through one.

```diff
-Environment.SetEnvironmentVariable(..., "21600"); // 6 hours
+Environment.SetEnvironmentVariable(..., "28800"); // 8 hours
```

Still only a *seed*: applied when the env var is unset, and both `MCP_PLUGIN_IDLE_TIMEOUT_SECONDS` and `--idle-timeout-seconds` still override it.

## The cost, and who must not pay it

An idle session pins its `SseEventWriter` buffer until evicted — up to tens of MiB after a large screenshot or response. On one developer's machine that is a handful of sessions and the cost is irrelevant. On a **multi-tenant host it is not**, which is why the comment now states the split explicitly rather than leaving the next reader to rediscover it:

| | local (this default) | hosted (ai-game.dev) |
|---|---|---|
| in-memory idle window | **8h** | `600s`, set explicitly |
| long-window resumption | not needed | Redis session-migration record |
| cost per retained session | tens of MiB | **491 B** (measured on prod) |

The two layers are independent, and that independence is the point: it lets a hosted deployment stay frugal with memory while still being generous about reconnect windows. Raising this seed does not push any cost onto the hosted side, because the hosted side overrides it.

## Verification

`dotnet build` clean, 0 warnings. No test asserts the old constant.

Separately I have a live experiment running against the published 9.2.4 image to confirm the seed actually takes effect end to end (session created with no env override, probed past the 10-minute mark, no Redis so only the in-memory window can keep it alive). Reporting the result on this PR — if the seed were somehow not applying, that would be a *different* bug and this change alone would not fix what users are seeing.

## Release

Second change queued for the next release, alongside #40 (log level). Not cutting it here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)