### PR TITLE
docs: drop the stale preview pin and the snapshot note from the compatibility table

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,10 +167,12 @@ Each written config is **URL-only** (credentials are never written into project 
 
 | GameDev-MCP-Server | McpPlugin.Server | ReflectorNet | Engine plugins |
 | --- | --- | --- | --- |
-| 8.0.3 (released) | 6.11.0 | 5.3.1 | engine plugins on McpPlugin **6.x** |
-| 9.0.0 (released) | 7.0.0-preview.1 | 5.3.2 | engine plugins on McpPlugin **7.x** (Phase 4) |
+| **9.2.4** (current) | 7.5.2 | 5.4.0 | engine plugins on McpPlugin **7.x** |
+| 8.0.3 (legacy) | 6.11.0 | 5.3.1 | engine plugins on McpPlugin **6.x** |
 
-> **Development snapshot.** The released `9.0.0` server line builds against **McpPlugin.Server 7.0.0-preview.1** (the mcp-authorize resource-server major). The `main` branch is now an in-development **`9.1.0`** snapshot building against **McpPlugin.Server 7.1.1** — its `<Version>` / `server.json` version bump and the Docker/zip/dotnet-tool publish are a separate, owner-gated release step. Any `9.x` server needs an engine plugin built on McpPlugin **7.x** (the instance-metadata handshake + `oauth` mode); older McpPlugin 6.x plugins pair with the released `8.0.3` server line.
+Any `9.x` server needs an engine plugin built on McpPlugin **7.x** (the instance-metadata handshake + `oauth` mode). McpPlugin 6.x plugins pair with the `8.0.3` line.
+
+Every `9.x` release since `9.0.0` builds against a released McpPlugin.Server 7.x. For the exact pins of an intermediate version, see its entry on [Releases](https://github.com/IvanMurzak/GameDev-MCP-Server/releases) — this table tracks the current release and the last 6.x-compatible one rather than every patch, so it does not go stale between them.
 
 ## License
 

--- a/docs/NUGET.md
+++ b/docs/NUGET.md
@@ -84,10 +84,10 @@ Write a pinned, URL-only MCP client config for an AI agent from the terminal:
 
 | GameDev-MCP-Server | McpPlugin.Server | ReflectorNet | Engine plugins |
 | --- | --- | --- | --- |
-| 8.0.3 (released) | 6.11.0 | 5.3.1 | engine plugins on McpPlugin 6.x |
-| 9.0.0 (released) | 7.0.0-preview.1 | 5.3.2 | engine plugins on McpPlugin 7.x (Phase 4) |
+| 9.2.4 (current) | 7.5.2 | 5.4.0 | engine plugins on McpPlugin 7.x |
+| 8.0.3 (legacy) | 6.11.0 | 5.3.1 | engine plugins on McpPlugin 6.x |
 
-The released `9.0.0` server line builds against McpPlugin.Server 7.0.0-preview.1 (the OAuth resource-server major). The `main` branch is now an in-development `9.1.0` snapshot building against McpPlugin.Server 7.1.1; its version bump + publish is a separate owner-gated release step. Older McpPlugin 6.x engine plugins pair with the released `8.0.3` server line.
+Any `9.x` server needs an engine plugin built on McpPlugin 7.x (the instance-metadata handshake + `oauth` mode); McpPlugin 6.x plugins pair with the `8.0.3` line. Every `9.x` release since `9.0.0` builds against a released McpPlugin.Server 7.x — for the exact pins of an intermediate version see its entry on [Releases](https://github.com/IvanMurzak/GameDev-MCP-Server/releases).
 
 ## Links
 


### PR DESCRIPTION
## What was wrong

The compatibility table advertised a **preview** dependency that no shipped version uses:

| claimed | actual |
|---|---|
| current line is `9.0.0` | `9.2.4`, published 2026-07-28 |
| built against `McpPlugin.Server 7.0.0-preview.1` | `7.5.2` — released |
| ReflectorNet `5.3.2` | `5.4.0` |
| main is an "in-development `9.1.0` snapshot" | main is post-`9.2.4` |

The preview pin was real for exactly one release — `9.0.0` on 2026-07-14 — and was superseded four releases later. Verified against the tags:

```
v8.0.3   ReflectorNet 5.3.1  McpPlugin.Server 6.11.0
v9.0.0   ReflectorNet 5.3.2  McpPlugin.Server 7.0.0-preview.1
v9.1.0   ReflectorNet 5.3.2  McpPlugin.Server 7.1.0
v9.2.0   ReflectorNet 5.3.2  McpPlugin.Server 7.3.0
v9.2.4   ReflectorNet 5.4.0  McpPlugin.Server 7.5.2
```

Telling an evaluator we ship against unreleased packages is worse than having no table at all, which is why this is worth more than a number swap.

## What changed

Two rows — the current release and the last 6.x-compatible one — because that is what the table is *for*: which server pairs with which engine plugin. Intermediate `9.x` pins point at the Releases page rather than being duplicated (and re-staled) here.

The **"Development snapshot" note is deleted, not updated.** A paragraph narrating what `main` happens to build against today is guaranteed to be wrong by the next merge, and this one duly was — it survived nine releases while describing a version that never shipped under that description. Replacing it with a fresh snapshot note would just restart the clock. What remains states only things that stay true between releases.

Applied to `docs/NUGET.md` too, since that is what nuget.org renders. Note that a readme fix only becomes visible on nuget.org when a **new version** is published — the readme is baked into the `.nupkg`.

No remaining `preview` / `snapshot` / `in-development` claims in either file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)