### PR TITLE
chore: bump McpPlugin to 8.0.0

### DIFF
--- a/com.IvanMurzak.GameDev.MCP.Server.csproj
+++ b/com.IvanMurzak.GameDev.MCP.Server.csproj
@@ -57,14 +57,14 @@
   -->
   <ItemGroup Condition="'$(UseLocalMcpPlugin)' != 'true'">
     <PackageReference Include="com.IvanMurzak.ReflectorNet" Version="5.4.0" />
-    <PackageReference Include="com.IvanMurzak.McpPlugin.Server" Version="7.5.2" />
+    <PackageReference Include="com.IvanMurzak.McpPlugin.Server" Version="8.0.0" />
     <!--
       Base McpPlugin package: the McpPlugin.Server package does NOT depend on it, but it hosts the
       shared AI-agent configurator registry (AiAgentConfiguratorRegistry) + ProjectIdentity /
       ProjectMarker primitives the `configure` subcommand consumes from the terminal. Pinned in
       lockstep with McpPlugin.Server.
     -->
-    <PackageReference Include="com.IvanMurzak.McpPlugin" Version="7.5.0" />
+    <PackageReference Include="com.IvanMurzak.McpPlugin" Version="8.0.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(UseLocalMcpPlugin)' == 'true'">


### PR DESCRIPTION
Automated downstream bump of `com.IvanMurzak.McpPlugin` `7.5.2` -> `8.0.0` (MCP-Plugin-dotnet release aefc8998ce1f).