### PR TITLE
chore: bump McpPlugin.Server + McpPlugin to 8.2.0

### DIFF
--- a/com.IvanMurzak.GameDev.MCP.Server.csproj
+++ b/com.IvanMurzak.GameDev.MCP.Server.csproj
@@ -57,14 +57,14 @@
   -->
   <ItemGroup Condition="'$(UseLocalMcpPlugin)' != 'true'">
     <PackageReference Include="com.IvanMurzak.ReflectorNet" Version="5.4.0" />
-    <PackageReference Include="com.IvanMurzak.McpPlugin.Server" Version="8.1.0" />
+    <PackageReference Include="com.IvanMurzak.McpPlugin.Server" Version="8.2.0" />
     <!--
       Base McpPlugin package: the McpPlugin.Server package does NOT depend on it, but it hosts the
       shared AI-agent configurator registry (AiAgentConfiguratorRegistry) + ProjectIdentity /
       ProjectMarker primitives the `configure` subcommand consumes from the terminal. Pinned in
       lockstep with McpPlugin.Server.
     -->
-    <PackageReference Include="com.IvanMurzak.McpPlugin" Version="8.1.0" />
+    <PackageReference Include="com.IvanMurzak.McpPlugin" Version="8.2.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(UseLocalMcpPlugin)' == 'true'">


### PR DESCRIPTION
**Hop 2 of a 4-hop delivery chain** for taskflow task W5.4.

`shared/MCP-Plugin-dotnet` gained a server-side MCP **replace-by-identity** rule keyed on `(accountSub, instanceId, projectPin)`, with `accountSub` resolved from the credential. It ships under security gate **SG-5** — *the installation identifier ships only together with its server-side consumer*. This repo's pins were still at 8.1.0, so the published rule reached nothing.

## What moved

`com.IvanMurzak.GameDev.MCP.Server.csproj` only — 2 lines:

| Package | Before | After |
| --- | --- | --- |
| `com.IvanMurzak.McpPlugin.Server` | 8.1.0 | **8.2.0** |
| `com.IvanMurzak.McpPlugin` | 8.1.0 | **8.2.0** |

Both move together because the csproj requires it — the base package is *"Pinned in lockstep with McpPlugin.Server."*

Not changed:
- `com.IvanMurzak.ReflectorNet` stays **5.4.0** — McpPlugin.Server 8.2.0 depends on exactly 5.4.0, so the pin is already correct.
- `com.IvanMurzak.McpPlugin.Common` uplifts **transitively** 8.1.0 → 8.2.0 (not pinned here).
- `<Version>` is untouched — this is a dependency bump, not a release.

This matches the precedent set by #46 (the 8.1.0 bump), which was also csproj-only.

## Verification that 8.2.0 is published

Checked against the NuGet registry, not a build log:

- `com.IvanMurzak.McpPlugin.Server` — `8.2.0` present in the flat-container index.
- `com.IvanMurzak.McpPlugin` — `8.2.0` present.
- Both nuspecs carry `<repository commit="56bc80b251a9006a90dc2b188a94c81a9691662a" />`, i.e. they are provably built from hop 1's merge commit `56bc80b2` (MCP-Plugin-dotnet #210) rather than merely sharing a version number.

## Build / test evidence

Baseline captured **before** the bump so any failure would be attributable:

| Stage | Result |
| --- | --- |
| Tests at 8.1.0 (baseline) | 49 passed / 0 failed |
| `dotnet build -c Release` at 8.2.0 | Build succeeded — 0 warnings, 0 errors |
| Tests at 8.2.0 | **49 passed / 0 failed** — identical to baseline |
| Runtime smoke | Server boots and listens against the 8.2.0 assemblies |

No behaviour asserted by this repo changed, so no test was adjusted.

Resolved (not merely declared) versions read back from `bin/Release/net9.0/gamedev-mcp-server.deps.json`: `McpPlugin/8.2.0`, `McpPlugin.Common/8.2.0`, `McpPlugin.Server/8.2.0`, `ReflectorNet/5.4.0`.

The Release build only proves compile-time binding, so the binary was also run: it initializes the host and starts listening, confirming the new assemblies load at runtime (no `TypeLoadException` / `MissingMethodException`).

## Scope

Deliberately stops here. `cloud/AI-Game-Dev-Server` — its vendored fallback pins in `mcp-server/McpServer.csproj` and the deployed image tag at `docker-compose.yml:64` — is **hop 3/4 and sequenced separately**; untouched by this PR.

Per the task's Definition of Done, this change is **not in production** and must not be reported as such until `cloud/AI-Game-Dev-Server/docker-compose.yml:64` names an image built from it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
