### PR TITLE
chore: release GameDev-MCP-Server 9.2.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,12 +167,13 @@ Each written config is **URL-only** (credentials are never written into project 
 
 | GameDev-MCP-Server | McpPlugin.Server | ReflectorNet | Engine plugins |
 | --- | --- | --- | --- |
-| **9.2.4** (current) | 7.5.2 | 5.4.0 | engine plugins on McpPlugin **7.x** |
+| **9.2.6** (current) | 8.2.0 | 5.4.0 | engine plugins on McpPlugin **8.x** |
+| 9.2.4 (last 7.x) | 7.5.2 | 5.4.0 | engine plugins on McpPlugin **7.x** |
 | 8.0.3 (legacy) | 6.11.0 | 5.3.1 | engine plugins on McpPlugin **6.x** |
 
-Any `9.x` server needs an engine plugin built on McpPlugin **7.x** (the instance-metadata handshake + `oauth` mode). McpPlugin 6.x plugins pair with the `8.0.3` line.
+Server releases `9.2.5` and newer build against McpPlugin **8.x**; `9.0.0`–`9.2.4` build against McpPlugin **7.x** (the instance-metadata handshake + `oauth` mode), and McpPlugin 6.x plugins pair with the `8.0.3` line.
 
-Every `9.x` release since `9.0.0` builds against a released McpPlugin.Server 7.x. For the exact pins of an intermediate version, see its entry on [Releases](https://github.com/IvanMurzak/GameDev-MCP-Server/releases) — this table tracks the current release and the last 6.x-compatible one rather than every patch, so it does not go stale between them.
+For the exact pins of an intermediate version, see its entry on [Releases](https://github.com/IvanMurzak/GameDev-MCP-Server/releases) — this table tracks the current release and the last release on each earlier McpPlugin major rather than every patch, so it does not go stale between them.
 
 ## License
 

--- a/com.IvanMurzak.GameDev.MCP.Server.csproj
+++ b/com.IvanMurzak.GameDev.MCP.Server.csproj
@@ -13,7 +13,7 @@
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>gamedev-mcp-server</ToolCommandName>
     <PackageId>com.IvanMurzak.GameDev.MCP.Server</PackageId>
-    <Version>9.2.5</Version>
+    <Version>9.2.6</Version>
     <Authors>Ivan Murzak</Authors>
     <Company>Ivan Murzak</Company>
     <Copyright>Copyright © 2026 Ivan Murzak</Copyright>

--- a/docs/NUGET.md
+++ b/docs/NUGET.md
@@ -84,10 +84,11 @@ Write a pinned, URL-only MCP client config for an AI agent from the terminal:
 
 | GameDev-MCP-Server | McpPlugin.Server | ReflectorNet | Engine plugins |
 | --- | --- | --- | --- |
-| 9.2.4 (current) | 7.5.2 | 5.4.0 | engine plugins on McpPlugin 7.x |
+| 9.2.6 (current) | 8.2.0 | 5.4.0 | engine plugins on McpPlugin 8.x |
+| 9.2.4 (last 7.x) | 7.5.2 | 5.4.0 | engine plugins on McpPlugin 7.x |
 | 8.0.3 (legacy) | 6.11.0 | 5.3.1 | engine plugins on McpPlugin 6.x |
 
-Any `9.x` server needs an engine plugin built on McpPlugin 7.x (the instance-metadata handshake + `oauth` mode); McpPlugin 6.x plugins pair with the `8.0.3` line. Every `9.x` release since `9.0.0` builds against a released McpPlugin.Server 7.x — for the exact pins of an intermediate version see its entry on [Releases](https://github.com/IvanMurzak/GameDev-MCP-Server/releases).
+Server releases `9.2.5` and newer build against McpPlugin 8.x; `9.0.0`–`9.2.4` build against McpPlugin 7.x (the instance-metadata handshake + `oauth` mode), and McpPlugin 6.x plugins pair with the `8.0.3` line. For the exact pins of an intermediate version see its entry on [Releases](https://github.com/IvanMurzak/GameDev-MCP-Server/releases).
 
 ## Links
 

--- a/server.json
+++ b/server.json
@@ -7,13 +7,13 @@
     "url": "https://github.com/IvanMurzak/GameDev-MCP-Server",
     "source": "github"
   },
-  "version": "9.2.5",
+  "version": "9.2.6",
   "packages": [
     {
       "registry_type": "oci",
       "registry_base_url": "https://docker.io",
       "identifier": "aigamedeveloper/mcp-server",
-      "version": "9.2.5",
+      "version": "9.2.6",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
Release PR for **9.2.6** (patch). Cuts the first release that carries the McpPlugin 8.2.0 pins landed in #46 / #47.

## Version

- `<Version>` + `server.json` (both occurrences) 9.2.5 -> 9.2.6.
- Patch, per this repo's precedent: 9.2.5 shipped the McpPlugin.Server 7.5.2 -> 8.0.0 *major* dependency bump as a patch. The host's own surface is unchanged here; only the pinned packages moved.

## Compatibility table sync

`CLAUDE.md` requires README.md and `docs/NUGET.md` to be kept in sync on each release. Both were still describing **9.2.4**:

- current row -> `9.2.6` / McpPlugin.Server `8.2.0` / ReflectorNet `5.4.0` / engine plugins on McpPlugin 8.x
- added a `9.2.4` row as the last release on McpPlugin.Server 7.x (previously the "current" row)
- the prose claims "Any `9.x` server needs an engine plugin built on McpPlugin 7.x" and "Every `9.x` release since `9.0.0` builds against a released McpPlugin.Server 7.x" were **already false before this PR** — v9.2.5 shipped McpPlugin.Server/McpPlugin 8.0.0. Replaced with the per-major split (9.2.5+ on 8.x, 9.0.0-9.2.4 on 7.x, 8.0.3 on 6.x).

Verified against the pins at each tag rather than assumed:

| tag | McpPlugin.Server | McpPlugin |
| --- | --- | --- |
| v9.2.4 | 7.5.2 | 7.5.0 |
| v9.2.5 | 8.0.0 | 8.0.0 |
| this PR | 8.2.0 | 8.2.0 |

## Local verification

- `dotnet build -c Release` — clean, 0 warnings, 0 errors
- `dotnet test` — **49/49 passed**
- `dotnet pack` produces `com.IvanMurzak.GameDev.MCP.Server.9.2.6.nupkg`, which is exactly the filename `deploy_nuget.yml` asserts for tag `v9.2.6`
- confirmed the corrected `docs/NUGET.md` is baked into the `.nupkg` as `README.md`

Once merged, a published release `v9.2.6` triggers `deploy_docker.yml`, `deploy_nuget.yml` and `deploy_server_executables.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)